### PR TITLE
Fix case insensitive navigation

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -31,7 +31,7 @@ export default class NeighbouringFileNavigator extends Plugin {
 				: (currentItem - 1) % files.length
 			];
 
-		this.app.workspace.openLinkText(toFile.path, "", false);
+		this.app.workspace.getLeaf(false).openFile(toFile as TFile);
 	}
 
 	async onload() {

--- a/main.ts
+++ b/main.ts
@@ -3,15 +3,17 @@ import { Plugin, TFile } from "obsidian";
 export default class NeighbouringFileNavigator extends Plugin {
 	getNeighbouringFiles(file: TFile) {
 		const files = file.parent?.children;
-		return files;
+		const filteredFiles = files?.filter(file => file instanceof TFile && file.extension === 'md');
+		const sortedFiles = filteredFiles?.sort((a, b) => (a.name > b.name ? 1 : -1));
+		return sortedFiles;
 	}
 
 	navigateToNeighbouringFile(next?: boolean) {
 		const activeFile = this.app.workspace.getActiveFile();
-		const files = activeFile?.parent?.children?.filter(file => file instanceof TFile && file.extension === 'md');
+		if (!activeFile) return;
 
-		files?.sort((a, b) => (a.name > b.name ? 1 : -1));
-		if (!activeFile || !files) return;
+		const files = this.getNeighbouringFiles(activeFile);
+		if (!files) return;
 
 		const currentItem = files.findIndex(
 			(item) => item.name === activeFile.name
@@ -20,10 +22,10 @@ export default class NeighbouringFileNavigator extends Plugin {
 		const toFile = next
 			? files[(currentItem + 1) % files.length]
 			: files[
-					currentItem == 0
-						? files.length - 1
-						: (currentItem - 1) % files.length
-			  ];
+			currentItem == 0
+				? files.length - 1
+				: (currentItem - 1) % files.length
+			];
 
 		this.app.workspace.openLinkText(toFile.path, "", false);
 	}
@@ -42,5 +44,5 @@ export default class NeighbouringFileNavigator extends Plugin {
 		});
 	}
 
-	onunload() {}
+	onunload() { }
 }

--- a/main.ts
+++ b/main.ts
@@ -4,7 +4,11 @@ export default class NeighbouringFileNavigator extends Plugin {
 	getNeighbouringFiles(file: TFile) {
 		const files = file.parent?.children;
 		const filteredFiles = files?.filter(file => file instanceof TFile && file.extension === 'md');
-		const sortedFiles = filteredFiles?.sort((a, b) => (a.name > b.name ? 1 : -1));
+		const sortedFiles = filteredFiles?.sort((a, b) =>
+			a.name.localeCompare(b.name, undefined, {
+				numeric: true,
+				sensitivity: 'base',
+			}))
 		return sortedFiles;
 	}
 

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 VAULT=${HOME}/notes
-FILES=main.js styles.css manifest.json
+FILES=main.js manifest.json
 
 clean:
 	-rm -rf *.js *.css
@@ -7,9 +7,9 @@ clean:
 build:
 	npm run build
 
-install:
-	-mkdir $(VAULT)/.obsidian/plugins/obsidian-neighbouring-files-plugin/
-	-cp -rf $(FILES) $(VAULT)/.obsidian/plugins/obsidian-neighbouring-files-plugin/
+install: build
+	-mkdir $(VAULT)/.obsidian/plugins/neighbouring-files/
+	-cp -rf $(FILES) $(VAULT)/.obsidian/plugins/neighbouring-files/
 
 dev:
 	npm run dev


### PR DESCRIPTION
- ignore case for navigating neighbouring files (fixes https://github.com/FabianUntermoser/obsidian-neighbouring-files-plugin/issues/7)
- ignore accent letters navigating neighbouring files (à considered as a)