### PR TITLE
Support File Sorting through Modification/Creation Timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,8 @@
 # Navigate to Neighbouring Files
 
-This [Obsidian](https://obsidian.md/) Plugin adds two commands.
+This [Obsidian](https://obsidian.md/) Plugin adds navigational commands that lets you quickly navigate to neighbouring files.
 
-- Neighbouring Files: Navigate to next file
-- Neighbouring Files: Navigate to prev file
-
-This enables you to navigate to a file located immediately before or after the currently active one.
-Files are sorted based on their file name.
-
-## Examples
+### Use Case
 
 - Navigate to the next weekly from `2023-W17` to `2023-W18`
 - Navigate to the next daily from `2023-04-31` to `2023-05-01`
@@ -16,20 +10,46 @@ Files are sorted based on their file name.
 
 [obsidian-neighbouring-files.webm](https://github.com/user-attachments/assets/cdc04e2b-e3d9-4d77-8b2c-cbfa4ef4436d)
 
+### Features
 
-## How I use this
+The sort order for the default command is configurable in the plugin settings.
 
-I map both commands to a shortcut using the [obsidian-vimrc-support](https://github.com/esm7/obsidian-vimrc-support) Plugin.
-Here's my configuration from my `.obsidian.vimrc`.
+Default Commands:
+- Navigate to next file
+- Navigate to prev file
+
+Specific Commands:
+- Navigate to next file (alphabetical)
+- Navigate to prev file (alphabetical)
+- Navigate to next file (creation timestamp)
+- Navigate to prev file (creation timestamp)
+- Navigate to next file (modified timestamp)
+- Navigate to prev file (modified timestamp)
+
+Supported Sorting Modes:
+- Alphabetical: Ordered by file names. (default)
+- By Modification Timestamp: Based on the last modified date.
+- By Creation Timestamp: Based on the file creation date.
+
+## Configuration
+
+Configure a hotkey to trigger the commands.
+
+Or use the [obsidian-vimrc-support](https://github.com/esm7/obsidian-vimrc-support) Plugin to map more useful hotkeys such as `gn` or `gp`
+(Caveat: This only works when the editor mode is on).
+
+Example `.obsidian.vimrc`.
 
 ```vimrc
 " navigation to neighbouring files
 exmap next_file obcommand neighbouring-files:next
 exmap prev_file obcommand neighbouring-files:prev
+exmap next_file_alphabetical obcommand neighbouring-files:next-alphabetical
+exmap prev_file_alphabetical obcommand neighbouring-files:prev-alphabetical
+exmap next_file_created obcommand neighbouring-files:next-created
+exmap prev_file_created obcommand neighbouring-files:prev-created
+exmap next_file_modified obcommand neighbouring-files:next-modified
+exmap prev_file_modified obcommand neighbouring-files:prev-modified
 nmap gn :next_file<cr>
 nmap gp :prev_file<cr>
 ```
-
-This enables me to navigate to neighbouring files quickly.
-
-Caveat: This only works when the editor mode is on.

--- a/makefile
+++ b/makefile
@@ -8,7 +8,7 @@ build:
 	npm run build
 
 install: build
-	-mkdir $(VAULT)/.obsidian/plugins/neighbouring-files/
+	-mkdir -p $(VAULT)/.obsidian/plugins/neighbouring-files/
 	-cp -rf $(FILES) $(VAULT)/.obsidian/plugins/neighbouring-files/
 
 dev:

--- a/src/NeighbouringFileNavigator.ts
+++ b/src/NeighbouringFileNavigator.ts
@@ -12,6 +12,28 @@ export default class NeighbouringFileNavigator {
 		this.navigateToNeighbouringFile(workspace, false);
 	}
 
+	public static navigateToNextModifiedFile(workspace: Workspace) {
+		console.debug("navigateToNextModifiedFile");
+		// NOT IMPLEMENTED
+		this.navigateToNeighbouringFile(workspace, false);
+	}
+
+	public static navigateToPrevModifiedFile(workspace: Workspace) {
+		console.debug("navigateToPrevModifiedFile");
+		// NOT IMPLEMENTED
+	}
+
+	public static navigateToNextCreatedFile(workspace: Workspace) {
+		console.debug("navigateToNextCreatedFile");
+		// NOT IMPLEMENTED
+	}
+
+	public static navigateToPrevCreatedFile(workspace: Workspace) {
+		console.debug("navigateToPrevCreatedFile");
+		// NOT IMPLEMENTED
+	}
+
+
 	public static navigateToNeighbouringFile(workspace: Workspace, next?: boolean) {
 		const activeFile = workspace.getActiveFile();
 		if (!activeFile) return;

--- a/src/NeighbouringFileNavigator.ts
+++ b/src/NeighbouringFileNavigator.ts
@@ -1,3 +1,4 @@
+import NeighbouringFileNavigatorPluginSettings, { SORT_ORDER } from "NeighbouringFileNavigatorPluginSettings";
 import { TFile, Workspace } from "obsidian";
 
 export type SortFn = (a: TFile, b: TFile) => number;
@@ -15,13 +16,31 @@ export class NeighbouringFileNavigator {
 
 	public static ctimeSorter: SortFn = (a: TFile, b: TFile) => { return a.stat.ctime - b.stat.ctime; };
 
-	public static navigateToNextFile(workspace: Workspace) {
-		console.debug("navigateToNextFile");
+	static sorters: Record<SORT_ORDER, SortFn> = {
+		alphabetical: this.localeSorter,
+		byCreatedTime: this.ctimeSorter,
+		byModifiedTime: this.mtimeSorter,
+	};
+
+	public static navigateToNextFile(workspace: Workspace, settings: NeighbouringFileNavigatorPluginSettings) {
+		console.debug("navigateToNextFile with sort mode", settings.defaultSortOrder);
+		const sortFn = this.sorters[settings.defaultSortOrder];
+		this.navigateToNeighbouringFile(workspace, sortFn, true);
+	}
+
+	public static navigateToPrevFile(workspace: Workspace, settings: NeighbouringFileNavigatorPluginSettings) {
+		console.debug("navigateToPrevFile with sort mode", settings.defaultSortOrder);
+		const sortFn = this.sorters[settings.defaultSortOrder];
+		this.navigateToNeighbouringFile(workspace, sortFn, false);
+	}
+
+	public static navigateToNextAlphabeticalFile(workspace: Workspace) {
+		console.debug("navigateToNextAlphabeticalFile");
 		this.navigateToNeighbouringFile(workspace, this.localeSorter, true);
 	}
 
-	public static navigateToPrevFile(workspace: Workspace) {
-		console.debug("navigateToPrevFile");
+	public static navigateToPrevAlphabeticalFile(workspace: Workspace) {
+		console.debug("navigateToPrevAlphabeticalFile");
 		this.navigateToNeighbouringFile(workspace, this.localeSorter, false);
 	}
 

--- a/src/NeighbouringFileNavigator.ts
+++ b/src/NeighbouringFileNavigator.ts
@@ -1,42 +1,55 @@
 import { TFile, Workspace } from "obsidian";
 
-export default class NeighbouringFileNavigator {
+export type SortFn = (a: TFile, b: TFile) => number;
+
+export class NeighbouringFileNavigator {
+
+	public static localeSorter: SortFn = (a: TFile, b: TFile) =>
+		a.basename.localeCompare(
+			b.basename,
+			undefined,
+			{ numeric: true, sensitivity: 'base' }
+		);
+
+	public static mtimeSorter: SortFn = (a: TFile, b: TFile) => { return a.stat.mtime - b.stat.mtime; };
+
+	public static ctimeSorter: SortFn = (a: TFile, b: TFile) => { return a.stat.ctime - b.stat.ctime; };
 
 	public static navigateToNextFile(workspace: Workspace) {
 		console.debug("navigateToNextFile");
-		this.navigateToNeighbouringFile(workspace, true);
+		this.navigateToNeighbouringFile(workspace, this.localeSorter, true);
 	}
 
 	public static navigateToPrevFile(workspace: Workspace) {
 		console.debug("navigateToPrevFile");
-		this.navigateToNeighbouringFile(workspace, false);
+		this.navigateToNeighbouringFile(workspace, this.localeSorter, false);
 	}
 
 	public static navigateToNextCreatedFile(workspace: Workspace) {
 		console.debug("navigateToNextCreatedFile");
-		this.navigateToNeighbouringCreatedFile(workspace, true);
+		this.navigateToNeighbouringFile(workspace, this.ctimeSorter, true);
 	}
 
 	public static navigateToPrevCreatedFile(workspace: Workspace) {
 		console.debug("navigateToPrevCreatedFile");
-		this.navigateToNeighbouringCreatedFile(workspace, false);
+		this.navigateToNeighbouringFile(workspace, this.ctimeSorter, false);
 	}
 
 	public static navigateToNextModifiedFile(workspace: Workspace) {
 		console.debug("navigateToNextModifiedFile");
-		this.navigateToNeighbouringModifiedFile(workspace, true);
+		this.navigateToNeighbouringFile(workspace, this.mtimeSorter, true);
 	}
 
 	public static navigateToPrevModifiedFile(workspace: Workspace) {
 		console.debug("navigateToPrevModifiedFile");
-		this.navigateToNeighbouringModifiedFile(workspace, false);
+		this.navigateToNeighbouringFile(workspace, this.mtimeSorter, false);
 	}
 
-	public static navigateToNeighbouringFile(workspace: Workspace, next?: boolean) {
+	public static navigateToNeighbouringFile(workspace: Workspace, sortFn: SortFn, next?: boolean) {
 		const activeFile = workspace.getActiveFile();
 		if (!activeFile) return;
 
-		const files = NeighbouringFileNavigator.getNeighbouringFiles(activeFile);
+		const files = this.getNeighbouringFiles(activeFile, sortFn)
 		if (!files) return;
 
 		const currentItem = files.findIndex(
@@ -49,77 +62,15 @@ export default class NeighbouringFileNavigator {
 			currentItem == 0
 				? files.length - 1
 				: (currentItem - 1) % files.length
-			];
+		];
 
 		workspace.getLeaf(false).openFile(toFile as TFile);
 	}
 
-	public static navigateToNeighbouringCreatedFile(workspace: Workspace, next?: boolean) {
-		const activeFile = workspace.getActiveFile();
-		if (!activeFile) return;
-
-		const files = NeighbouringFileNavigator.getNeighbouringCreatedFiles(activeFile);
-		if (!files) return;
-
-		const currentItem = files.findIndex(
-			(item) => item.name === activeFile.name
-		);
-
-		const toFile = next
-			? files[(currentItem + 1) % files.length]
-			: files[
-			currentItem == 0
-				? files.length - 1
-				: (currentItem - 1) % files.length
-			];
-
-		workspace.getLeaf(false).openFile(toFile as TFile);
-	}
-
-	public static navigateToNeighbouringModifiedFile(workspace: Workspace, next?: boolean) {
-		const activeFile = workspace.getActiveFile();
-		if (!activeFile) return;
-
-		const files = NeighbouringFileNavigator.getNeighbouringModifiedFiles(activeFile);
-		if (!files) return;
-
-		const currentItem = files.findIndex(
-			(item) => item.name === activeFile.name
-		);
-
-		const toFile = next
-			? files[(currentItem + 1) % files.length]
-			: files[
-			currentItem == 0
-				? files.length - 1
-				: (currentItem - 1) % files.length
-			];
-
-		workspace.getLeaf(false).openFile(toFile as TFile);
-	}
-
-	public static getNeighbouringFiles(file: TFile) {
+	public static getNeighbouringFiles(file: TFile, sortFn: SortFn) {
 		const files = file?.parent?.children;
 		const filteredFiles = files?.filter(f => f instanceof TFile && f.extension === 'md') as TFile[];
-		const sortedFiles = filteredFiles?.sort((a, b) =>
-			a.basename.localeCompare(b.basename, undefined, {
-				numeric: true,
-				sensitivity: 'base',
-			}))
-		return sortedFiles;
-	}
-
-	public static getNeighbouringCreatedFiles(file: TFile) {
-		const files = file?.parent?.children;
-		const filteredFiles = files?.filter(f => f instanceof TFile && f.extension === 'md') as TFile[];
-		const sortedFiles = filteredFiles?.sort((a, b) => { return a.stat.ctime - b.stat.ctime; });
-		return sortedFiles;
-	}
-
-	public static getNeighbouringModifiedFiles(file: TFile) {
-		const files = file?.parent?.children;
-		const filteredFiles = files?.filter(f => f instanceof TFile && f.extension === 'md') as TFile[];
-		const sortedFiles = filteredFiles?.sort((a, b) => { return a.stat.mtime - b.stat.mtime; });
+		const sortedFiles = filteredFiles?.sort(sortFn);
 		return sortedFiles;
 	}
 

--- a/src/NeighbouringFileNavigator.ts
+++ b/src/NeighbouringFileNavigator.ts
@@ -3,10 +3,12 @@ import { TFile, Workspace } from "obsidian";
 export default class NeighbouringFileNavigator {
 
 	public static navigateToNextFile(workspace: Workspace) {
+		console.debug("navigateToNextFile");
 		this.navigateToNeighbouringFile(workspace, true);
 	}
 
 	public static navigateToPrevFile(workspace: Workspace) {
+		console.debug("navigateToPrevFile");
 		this.navigateToNeighbouringFile(workspace, false);
 	}
 

--- a/src/NeighbouringFileNavigator.ts
+++ b/src/NeighbouringFileNavigator.ts
@@ -12,33 +12,75 @@ export default class NeighbouringFileNavigator {
 		this.navigateToNeighbouringFile(workspace, false);
 	}
 
-	public static navigateToNextModifiedFile(workspace: Workspace) {
-		console.debug("navigateToNextModifiedFile");
-		// NOT IMPLEMENTED
-		this.navigateToNeighbouringFile(workspace, false);
-	}
-
-	public static navigateToPrevModifiedFile(workspace: Workspace) {
-		console.debug("navigateToPrevModifiedFile");
-		// NOT IMPLEMENTED
-	}
-
 	public static navigateToNextCreatedFile(workspace: Workspace) {
 		console.debug("navigateToNextCreatedFile");
-		// NOT IMPLEMENTED
+		this.navigateToNeighbouringCreatedFile(workspace, true);
 	}
 
 	public static navigateToPrevCreatedFile(workspace: Workspace) {
 		console.debug("navigateToPrevCreatedFile");
-		// NOT IMPLEMENTED
+		this.navigateToNeighbouringCreatedFile(workspace, false);
 	}
 
+	public static navigateToNextModifiedFile(workspace: Workspace) {
+		console.debug("navigateToNextModifiedFile");
+		this.navigateToNeighbouringModifiedFile(workspace, true);
+	}
+
+	public static navigateToPrevModifiedFile(workspace: Workspace) {
+		console.debug("navigateToPrevModifiedFile");
+		this.navigateToNeighbouringModifiedFile(workspace, false);
+	}
 
 	public static navigateToNeighbouringFile(workspace: Workspace, next?: boolean) {
 		const activeFile = workspace.getActiveFile();
 		if (!activeFile) return;
 
 		const files = NeighbouringFileNavigator.getNeighbouringFiles(activeFile);
+		if (!files) return;
+
+		const currentItem = files.findIndex(
+			(item) => item.name === activeFile.name
+		);
+
+		const toFile = next
+			? files[(currentItem + 1) % files.length]
+			: files[
+			currentItem == 0
+				? files.length - 1
+				: (currentItem - 1) % files.length
+			];
+
+		workspace.getLeaf(false).openFile(toFile as TFile);
+	}
+
+	public static navigateToNeighbouringCreatedFile(workspace: Workspace, next?: boolean) {
+		const activeFile = workspace.getActiveFile();
+		if (!activeFile) return;
+
+		const files = NeighbouringFileNavigator.getNeighbouringCreatedFiles(activeFile);
+		if (!files) return;
+
+		const currentItem = files.findIndex(
+			(item) => item.name === activeFile.name
+		);
+
+		const toFile = next
+			? files[(currentItem + 1) % files.length]
+			: files[
+			currentItem == 0
+				? files.length - 1
+				: (currentItem - 1) % files.length
+			];
+
+		workspace.getLeaf(false).openFile(toFile as TFile);
+	}
+
+	public static navigateToNeighbouringModifiedFile(workspace: Workspace, next?: boolean) {
+		const activeFile = workspace.getActiveFile();
+		if (!activeFile) return;
+
+		const files = NeighbouringFileNavigator.getNeighbouringModifiedFiles(activeFile);
 		if (!files) return;
 
 		const currentItem = files.findIndex(
@@ -64,6 +106,20 @@ export default class NeighbouringFileNavigator {
 				numeric: true,
 				sensitivity: 'base',
 			}))
+		return sortedFiles;
+	}
+
+	public static getNeighbouringCreatedFiles(file: TFile) {
+		const files = file?.parent?.children;
+		const filteredFiles = files?.filter(f => f instanceof TFile && f.extension === 'md') as TFile[];
+		const sortedFiles = filteredFiles?.sort((a, b) => { return a.stat.ctime - b.stat.ctime; });
+		return sortedFiles;
+	}
+
+	public static getNeighbouringModifiedFiles(file: TFile) {
+		const files = file?.parent?.children;
+		const filteredFiles = files?.filter(f => f instanceof TFile && f.extension === 'md') as TFile[];
+		const sortedFiles = filteredFiles?.sort((a, b) => { return a.stat.mtime - b.stat.mtime; });
 		return sortedFiles;
 	}
 

--- a/src/NeighbouringFileNavigator.ts
+++ b/src/NeighbouringFileNavigator.ts
@@ -2,6 +2,14 @@ import { TFile, Workspace } from "obsidian";
 
 export default class NeighbouringFileNavigator {
 
+	public static navigateToNextFile(workspace: Workspace) {
+		this.navigateToNeighbouringFile(workspace, true);
+	}
+
+	public static navigateToPrevFile(workspace: Workspace) {
+		this.navigateToNeighbouringFile(workspace, false);
+	}
+
 	public static navigateToNeighbouringFile(workspace: Workspace, next?: boolean) {
 		const activeFile = workspace.getActiveFile();
 		if (!activeFile) return;

--- a/src/NeighbouringFileNavigatorPluginSettingTab.ts
+++ b/src/NeighbouringFileNavigatorPluginSettingTab.ts
@@ -1,0 +1,34 @@
+import NeighbouringFileNavigatorPlugin from './main';
+import { App, PluginSettingTab, Setting } from 'obsidian';
+import { SORT_ORDER } from 'NeighbouringFileNavigatorPluginSettings';
+
+export default class NeighbouringFileNavigatorPluginSettingTab extends PluginSettingTab {
+	plugin: NeighbouringFileNavigatorPlugin;
+
+	constructor(app: App, plugin: NeighbouringFileNavigatorPlugin) {
+		super(app, plugin);
+		this.plugin = plugin;
+	}
+
+	display(): void {
+		let { containerEl } = this;
+
+		containerEl.empty();
+
+		new Setting(containerEl)
+			.setName('Default Sort Order')
+			.setDesc('Sort Order used for the default command')
+			.addDropdown((dropdown) => {
+				dropdown.addOption("alphabetical", "Alphabetical");
+				dropdown.addOption("byCreatedTime", "Creation Timestamp");
+				dropdown.addOption("byModifiedTime", "Modification Timestamp");
+				dropdown.setValue(this.plugin.settings.defaultSortOrder)
+				dropdown.onChange(async (value: SORT_ORDER) =>	{
+					console.log("sort order", this.plugin.settings.defaultSortOrder);
+					this.plugin.settings.defaultSortOrder = value;
+					console.log("setting sort order", value);
+					await this.plugin.saveSettings();
+				});
+			});
+	}
+}

--- a/src/NeighbouringFileNavigatorPluginSettings.ts
+++ b/src/NeighbouringFileNavigatorPluginSettings.ts
@@ -1,0 +1,5 @@
+export type SORT_ORDER = 'alphabetical' | 'byCreatedTime' | 'byModifiedTime';
+
+export default interface NeighbouringFileNavigatorPluginSettings {
+	defaultSortOrder: SORT_ORDER;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,20 @@
 import { NeighbouringFileNavigator } from "NeighbouringFileNavigator";
+import NeighbouringFileNavigatorPluginSettings from "NeighbouringFileNavigatorPluginSettings";
+import NeighbouringFileNavigatorPluginSettingTab from "NeighbouringFileNavigatorPluginSettingTab";
 import { Plugin } from "obsidian";
+
+const DEFAULT_SETTINGS: Partial<NeighbouringFileNavigatorPluginSettings> = {
+	defaultSortOrder: 'alphabetical',
+};
 
 export default class NeighbouringFileNavigatorPlugin extends Plugin {
 
+	settings: NeighbouringFileNavigatorPluginSettings;
+
 	async onload() {
+		await this.loadSettings();
+		this.addSettingTab(new NeighbouringFileNavigatorPluginSettingTab(this.app, this));
+
 		this.addCommand({
 			id: "next",
 			name: "Navigate to next file",
@@ -39,4 +50,12 @@ export default class NeighbouringFileNavigatorPlugin extends Plugin {
 	}
 
 	onunload() { }
+
+	async loadSettings() {
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+	}
+
+	async saveSettings() {
+		await this.saveData(this.settings);
+	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,12 +18,23 @@ export default class NeighbouringFileNavigatorPlugin extends Plugin {
 		this.addCommand({
 			id: "next",
 			name: "Navigate to next file",
-			callback: () => NeighbouringFileNavigator.navigateToNextFile(this.app.workspace),
+			callback: () => NeighbouringFileNavigator.navigateToNextFile(this.app.workspace, this.settings),
 		});
 		this.addCommand({
 			id: "prev",
 			name: "Navigate to previous file",
-			callback: () => NeighbouringFileNavigator.navigateToPrevFile(this.app.workspace),
+			callback: () => NeighbouringFileNavigator.navigateToPrevFile(this.app.workspace, this.settings),
+		});
+
+		this.addCommand({
+			id: "next-alphabetical",
+			name: "Navigate to next alphabetical file",
+			callback: () => NeighbouringFileNavigator.navigateToNextAlphabeticalFile(this.app.workspace),
+		});
+		this.addCommand({
+			id: "prev-alphabetical",
+			name: "Navigate to previous alphabetical file",
+			callback: () => NeighbouringFileNavigator.navigateToPrevAlphabeticalFile(this.app.workspace),
 		});
 
 		this.addCommand({

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,13 +7,13 @@ export default class NeighbouringFileNavigatorPlugin extends Plugin {
 		this.addCommand({
 			id: "next",
 			name: "Navigate to next file",
-			callback: () => NeighbouringFileNavigator.navigateToNeighbouringFile(this.app.workspace, true),
+			callback: () => NeighbouringFileNavigator.navigateToNextFile(this.app.workspace),
 		});
 
 		this.addCommand({
 			id: "prev",
 			name: "Navigate to previous file",
-			callback: () => NeighbouringFileNavigator.navigateToNeighbouringFile(this.app.workspace, false),
+			callback: () => NeighbouringFileNavigator.navigateToPrevFile(this.app.workspace),
 		});
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,11 +9,32 @@ export default class NeighbouringFileNavigatorPlugin extends Plugin {
 			name: "Navigate to next file",
 			callback: () => NeighbouringFileNavigator.navigateToNextFile(this.app.workspace),
 		});
-
 		this.addCommand({
 			id: "prev",
 			name: "Navigate to previous file",
 			callback: () => NeighbouringFileNavigator.navigateToPrevFile(this.app.workspace),
+		});
+
+		this.addCommand({
+			id: "next-created",
+			name: "Navigate to next created file",
+			callback: () => NeighbouringFileNavigator.navigateToNextCreatedFile(this.app.workspace),
+		});
+		this.addCommand({
+			id: "prev-created",
+			name: "Navigate to previous created file",
+			callback: () => NeighbouringFileNavigator.navigateToPrevCreatedFile(this.app.workspace),
+		});
+
+		this.addCommand({
+			id: "next-modified",
+			name: "Navigate to next modified file",
+			callback: () => NeighbouringFileNavigator.navigateToNextModifiedFile(this.app.workspace),
+		});
+		this.addCommand({
+			id: "prev-modified",
+			name: "Navigate to previous modified file",
+			callback: () => NeighbouringFileNavigator.navigateToPrevModifiedFile(this.app.workspace),
 		});
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,40 +22,40 @@ export default class NeighbouringFileNavigatorPlugin extends Plugin {
 		});
 		this.addCommand({
 			id: "prev",
-			name: "Navigate to previous file",
+			name: "Navigate to prev file",
 			callback: () => NeighbouringFileNavigator.navigateToPrevFile(this.app.workspace, this.settings),
 		});
 
 		this.addCommand({
 			id: "next-alphabetical",
-			name: "Navigate to next alphabetical file",
+			name: "Navigate to next file (alphabetical)",
 			callback: () => NeighbouringFileNavigator.navigateToNextAlphabeticalFile(this.app.workspace),
 		});
 		this.addCommand({
 			id: "prev-alphabetical",
-			name: "Navigate to previous alphabetical file",
+			name: "Navigate to prev file (alphabetical)",
 			callback: () => NeighbouringFileNavigator.navigateToPrevAlphabeticalFile(this.app.workspace),
 		});
 
 		this.addCommand({
 			id: "next-created",
-			name: "Navigate to next created file",
+			name: "Navigate to next file (creation timestamp)",
 			callback: () => NeighbouringFileNavigator.navigateToNextCreatedFile(this.app.workspace),
 		});
 		this.addCommand({
 			id: "prev-created",
-			name: "Navigate to previous created file",
+			name: "Navigate to prev file (creation timestamp)",
 			callback: () => NeighbouringFileNavigator.navigateToPrevCreatedFile(this.app.workspace),
 		});
 
 		this.addCommand({
 			id: "next-modified",
-			name: "Navigate to next modified file",
+			name: "Navigate to next file (modification timestamp)",
 			callback: () => NeighbouringFileNavigator.navigateToNextModifiedFile(this.app.workspace),
 		});
 		this.addCommand({
 			id: "prev-modified",
-			name: "Navigate to previous modified file",
+			name: "Navigate to prev file (modification timestamp)",
 			callback: () => NeighbouringFileNavigator.navigateToPrevModifiedFile(this.app.workspace),
 		});
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import NeighbouringFileNavigator from "NeighbouringFileNavigator";
+import { NeighbouringFileNavigator } from "NeighbouringFileNavigator";
 import { Plugin } from "obsidian";
 
 export default class NeighbouringFileNavigatorPlugin extends Plugin {

--- a/test/NeighbouringFileNavigator.test.ts
+++ b/test/NeighbouringFileNavigator.test.ts
@@ -1,5 +1,7 @@
-import NeighbouringFileNavigator from "NeighbouringFileNavigator";
+import { NeighbouringFileNavigator, SortFn } from "NeighbouringFileNavigator";
 import { FileStats, TAbstractFile, TFile, TFolder } from "obsidian";
+
+const createNote = (name: string, stats?: FileStats): TFile => createFile(name, "md", stats);
 
 const createFile = (name: string, extension: string, stats?: FileStats): TFile => {
 	const f = new TFile();
@@ -8,10 +10,6 @@ const createFile = (name: string, extension: string, stats?: FileStats): TFile =
 	f.name = `${name}.${extension}`;
 	f.stat = stats ? stats : { ctime: 1, mtime: 1, size: 1, };
 	return f;
-};
-
-const createNote = (name: string, stats?: FileStats): TFile => {
-	return createFile(name, "md", stats)
 };
 
 const createDir = (name: string): TFolder => {
@@ -33,9 +31,14 @@ const setupFiles = (names: Array<string>) => {
 	return setup(children);
 };
 
-const expectNeighbours = (files : Array<TFile> ) => {
+const expectNeighbours = (files: Array<TFile> ) => {
 	const names = files?.map(n => n.basename)
 	return expect(names)
+}
+
+const getNeighbouringFiles = (file: TFile | TAbstractFile, sortFn: SortFn = NeighbouringFileNavigator.localeSorter): Array<TFile> => {
+	const neighbours = NeighbouringFileNavigator.getNeighbouringFiles(file as TFile, sortFn)
+	return neighbours;
 }
 
 describe('NeighbouringFileNavigator', () => {
@@ -45,7 +48,7 @@ describe('NeighbouringFileNavigator', () => {
 		const files = setupFiles(["1", "2", "3"]);
 
 		// WHEN
-		const neighbours = NeighbouringFileNavigator.getNeighbouringFiles(files[0] as TFile)
+		const neighbours = getNeighbouringFiles(files[0])
 
 		// THEN
 		expect(neighbours).toHaveLength(3)
@@ -61,7 +64,7 @@ describe('NeighbouringFileNavigator', () => {
 		]);
 
 		// WHEN
-		const neighbours = NeighbouringFileNavigator.getNeighbouringFiles(files[0] as TFile)
+		const neighbours = getNeighbouringFiles(files[0])
 
 		// THEN
 		expect(neighbours).toHaveLength(2)
@@ -77,7 +80,7 @@ describe('NeighbouringFileNavigator', () => {
 		]);
 
 		// WHEN
-		const neighbours = NeighbouringFileNavigator.getNeighbouringFiles(files[0] as TFile)
+		const neighbours = getNeighbouringFiles(files[0])
 
 		// THEN
 		expect(neighbours).toHaveLength(1)
@@ -89,7 +92,7 @@ describe('NeighbouringFileNavigator', () => {
 		const files = setupFiles(["2", "1", "3"]);
 
 		// WHEN
-		const neighbours = NeighbouringFileNavigator.getNeighbouringFiles(files[0] as TFile)
+		const neighbours = getNeighbouringFiles(files[0])
 
 		// THEN
 		expectNeighbours(neighbours).toEqual(["1", "2", "3"])
@@ -100,7 +103,7 @@ describe('NeighbouringFileNavigator', () => {
 		const files = setupFiles(["test - 3", "Test - 2", "test - 1"]);
 
 		// WHEN
-		const neighbours = NeighbouringFileNavigator.getNeighbouringFiles(files[0] as TFile)
+		const neighbours = getNeighbouringFiles(files[0])
 
 		// THEN
 		expectNeighbours(neighbours).toEqual(["test - 1", "Test - 2", "test - 3"]);
@@ -120,7 +123,7 @@ describe('NeighbouringFileNavigator', () => {
 		]);
 
 		// WHEN
-		const neighbours = NeighbouringFileNavigator.getNeighbouringFiles(files[0] as TFile);
+		const neighbours = getNeighbouringFiles(files[0])
 
 		// THEN
 		expectNeighbours(neighbours).toEqual([
@@ -156,7 +159,7 @@ describe('NeighbouringFileNavigator', () => {
 		]);
 
 		// WHEN
-		const neighbours = NeighbouringFileNavigator.getNeighbouringCreatedFiles(files[0] as TFile)
+		const neighbours = getNeighbouringFiles(files[0], NeighbouringFileNavigator.ctimeSorter)
 
 		// THEN
 		expectNeighbours(neighbours).toEqual([ "1", "2", "3" ]);
@@ -183,7 +186,7 @@ describe('NeighbouringFileNavigator', () => {
 		]);
 
 		// WHEN
-		const neighbours = NeighbouringFileNavigator.getNeighbouringModifiedFiles(files[0] as TFile)
+		const neighbours = getNeighbouringFiles(files[0], NeighbouringFileNavigator.mtimeSorter)
 
 		// THEN
 		expectNeighbours(neighbours).toEqual([ "1", "2", "3" ]);

--- a/test/NeighbouringFileNavigator.test.ts
+++ b/test/NeighbouringFileNavigator.test.ts
@@ -135,4 +135,38 @@ describe('NeighbouringFileNavigator', () => {
 		]);
 	});
 
+	it('should sort modified files', () => {
+
+		const fileStats1: FileStats = {
+			ctime: 1672502400000, // 2023-01-01T00:00:00.000Z
+			mtime: 1675180800000, // 2023-02-01T00:00:00.000Z
+			size: 5242880,        // 5 MB
+		};
+
+		const fileStats2: FileStats = {
+			ctime: 1689876543210, // 2023-07-20T01:22:23.210Z
+			mtime: 1692456789100, // 2023-08-19T11:13:09.100Z
+			size: 102400,         // 100 KB
+		};
+
+		const fileStats3: FileStats = {
+			ctime: 1700989701724, // 2023-11-26T04:01:41.724Z
+			mtime: 1704025483489, // 2023-12-31T12:24:43.489Z
+			size: 4380,           // 4.38 KB
+		};
+
+		const f1 :TFile = createNote("1", fileStats1);
+		const f2 :TFile = createNote("2", fileStats2);
+		const f3 :TFile = createNote("3", fileStats3);
+
+		// GIVEN
+		const files = setup([f3,f2,f1]);
+
+		// WHEN
+		const neighbours = NeighbouringFileNavigator.getNeighbouringModifiedFiles(files[0] as TFile)
+
+		// THEN
+		expectNeighbours(neighbours).toEqual([ "1", "2", "3" ]);
+	});
+
 });

--- a/test/NeighbouringFileNavigator.test.ts
+++ b/test/NeighbouringFileNavigator.test.ts
@@ -135,32 +135,52 @@ describe('NeighbouringFileNavigator', () => {
 		]);
 	});
 
-	it('should sort modified files', () => {
-
-		const fileStats1: FileStats = {
-			ctime: 1672502400000, // 2023-01-01T00:00:00.000Z
-			mtime: 1675180800000, // 2023-02-01T00:00:00.000Z
-			size: 5242880,        // 5 MB
-		};
-
-		const fileStats2: FileStats = {
-			ctime: 1689876543210, // 2023-07-20T01:22:23.210Z
-			mtime: 1692456789100, // 2023-08-19T11:13:09.100Z
-			size: 102400,         // 100 KB
-		};
-
-		const fileStats3: FileStats = {
-			ctime: 1700989701724, // 2023-11-26T04:01:41.724Z
-			mtime: 1704025483489, // 2023-12-31T12:24:43.489Z
-			size: 4380,           // 4.38 KB
-		};
-
-		const f1 :TFile = createNote("1", fileStats1);
-		const f2 :TFile = createNote("2", fileStats2);
-		const f3 :TFile = createNote("3", fileStats3);
-
+	it('should sort files based on creation timestamp', () => {
 		// GIVEN
-		const files = setup([f3,f2,f1]);
+		const files = setup([
+			createNote("2", {
+				ctime: 1689876543210, // 2023-07-20T01:22:23.210Z
+				mtime: 1704025483489, // 2023-12-31T12:24:43.489Z
+				size: 4380,           // 4.38 KB
+			}),
+			createNote("3", {
+				ctime: 1700989701724, // 2023-11-26T04:01:41.724Z
+				mtime: 1692456789100, // 2023-08-19T11:13:09.100Z
+				size: 102400,         // 100 KB
+			}),
+			createNote("1", {
+				ctime: 1672502400000, // 2023-01-01T00:00:00.000Z
+				mtime: 1675180800000, // 2023-02-01T00:00:00.000Z
+				size: 5242880,        // 5 MB
+			})
+		]);
+
+		// WHEN
+		const neighbours = NeighbouringFileNavigator.getNeighbouringCreatedFiles(files[0] as TFile)
+
+		// THEN
+		expectNeighbours(neighbours).toEqual([ "1", "2", "3" ]);
+	});
+
+	it('should sort files based on midified timestamp', () => {
+		// GIVEN
+		const files = setup([
+			createNote("2", {
+				ctime: 1700989701724, // 2023-11-26T04:01:41.724Z
+				mtime: 1692456789100, // 2023-08-19T11:13:09.100Z
+				size: 5242880,        // 5 MB
+			}),
+			createNote("1", {
+				ctime: 1689876543210, // 2023-07-20T01:22:23.210Z
+				mtime: 1675180800000, // 2023-02-01T00:00:00.000Z
+				size: 102400,         // 100 KB
+			}),
+			createNote("3", {
+				ctime: 1672502400000, // 2023-01-01T00:00:00.000Z
+				mtime: 1704025483489, // 2023-12-31T12:24:43.489Z
+				size: 4380,           // 4.38 KB
+			})
+		]);
 
 		// WHEN
 		const neighbours = NeighbouringFileNavigator.getNeighbouringModifiedFiles(files[0] as TFile)

--- a/test/NeighbouringFileNavigator.test.ts
+++ b/test/NeighbouringFileNavigator.test.ts
@@ -1,12 +1,17 @@
 import NeighbouringFileNavigator from "NeighbouringFileNavigator";
-import { TAbstractFile, TFile, TFolder } from "obsidian";
+import { FileStats, TAbstractFile, TFile, TFolder } from "obsidian";
 
-const createFile = (name: string, extension: string = "md"): TFile => {
+const createFile = (name: string, extension: string, stats?: FileStats): TFile => {
 	const f = new TFile();
 	f.basename = name;
 	f.extension = extension;
 	f.name = `${name}.${extension}`;
+	f.stat = stats ? stats : { ctime: 1, mtime: 1, size: 1, };
 	return f;
+};
+
+const createNote = (name: string, stats?: FileStats): TFile => {
+	return createFile(name, "md", stats)
 };
 
 const createDir = (name: string): TFolder => {
@@ -24,7 +29,7 @@ const setup = (children: Array<TAbstractFile>) => {
 };
 
 const setupFiles = (names: Array<string>) => {
-	const children = names.map(c => createFile(c));
+	const children = names.map(c => createNote(c));
 	return setup(children);
 };
 
@@ -50,8 +55,8 @@ describe('NeighbouringFileNavigator', () => {
 	it('should only filter for markdown files', () => {
 		// GIVEN
 		const files = setup([
-			createFile("1"),
-			createFile("2"),
+			createNote("1"),
+			createNote("2"),
 			createFile("3", "pdf"),
 		]);
 
@@ -67,7 +72,7 @@ describe('NeighbouringFileNavigator', () => {
 	it('should filter out directories', () => {
 		// GIVEN
 		const files = setup([
-			createFile("1"),
+			createNote("1"),
 			createDir("somedir")
 		]);
 


### PR DESCRIPTION
Currently the navigation command relies on sorting files alphabetically.
This PR adds support for different modes of file sorting.
Fixes #13 

Design considerations:
- Use sort modes already known to Obsidian (alphabetically, by creation and by modification timestamps)
- Add one command for each sort mode, in order to allow assigning specific hotkeys/vimkeys.
- Add one default/global command based on a plugin setting or the file explorer setting.

I didn't find a proper way to access the file explorers sort mode in the Docs. 
However it can be obtained like this: 
`this.app.workspace.getLeavesOfType('file-explorer')[0].view.sortOrder`
(Taken from [File explorer API? - Developers: Plugin & API - Obsidian Forum](https://forum.obsidian.md/t/file-explorer-api/73329))
Working with Obsidian internals like this might break plugin behaviour in future updates. 
Therefore, using solely a setting seems more appropriate. 

Tasks:
- [x] Add sorting alphabetically, by creation and by modification timestamps
- [x] Adds specific navigation commands for each sort mode
  - "Navigate to next alphabetical file" / "Navigate to previous alphabetical file"  
  - "Navigate to next created file" / "Navigate to previous created file"
  - "Navigate to next modified file" / "Navigate to previous modified file"
- [x] Add plugin settings page with dropdown for default sort mode
- [x] Add default navigation command using sort mode defined in plugin settings page
  - "Navigate to next file" and "Navigate to previous file"