### PR TITLE
feat: support reverse sorting and use file explorer sort order

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,16 @@ This [Obsidian](https://obsidian.md/) Plugin adds navigational commands that let
 
 [obsidian-neighbouring-files.webm](https://github.com/user-attachments/assets/cdc04e2b-e3d9-4d77-8b2c-cbfa4ef4436d)
 
-### Features
+### Usage
 
-The sort order for the default command is configurable in the plugin settings.
+The default command uses the sort order from the [File explorer](https://help.obsidian.md/Plugins/File+explorer).
+A fallback sort order is configurable in the plugin settings.
 
 Default Commands:
 - Navigate to next file
 - Navigate to prev file
 
-Specific Commands:
+Commands:
 - Navigate to next file (alphabetical)
 - Navigate to prev file (alphabetical)
 - Navigate to next file (creation timestamp)
@@ -27,8 +28,8 @@ Specific Commands:
 - Navigate to prev file (modified timestamp)
 
 Supported Sorting Modes:
-- Alphabetical: Ordered by file names. (default)
-- By Modification Timestamp: Based on the last modified date.
+- Alphabetical: Ordered by file names.
+- By Modification Timestamp: Based on the file modification date.
 - By Creation Timestamp: Based on the file creation date.
 
 ## Configuration

--- a/src/NeighbouringFileNavigator.ts
+++ b/src/NeighbouringFileNavigator.ts
@@ -11,27 +11,22 @@ export class NeighbouringFileNavigator {
 			undefined,
 			{ numeric: true, sensitivity: 'base' }
 		);
-	
-	public static localeSorterReverse: SortFn = (a: TFile, b: TFile) =>
-		b.basename.localeCompare(
-			a.basename,
-			undefined,
-			{ numeric: true, sensitivity: 'base' }
-		);
 
-	public static mtimeSorterReverse: SortFn = (a: TFile, b: TFile) => { return a.stat.mtime - b.stat.mtime; };
 	public static mtimeSorter: SortFn = (a: TFile, b: TFile) => { return b.stat.mtime - a.stat.mtime; };
 
-	public static ctimeSorterReverse: SortFn = (a: TFile, b: TFile) => { return a.stat.ctime - b.stat.ctime; };
 	public static ctimeSorter: SortFn = (a: TFile, b: TFile) => { return b.stat.ctime - a.stat.ctime; };
+	
+	public static reverse(fn: SortFn): SortFn {
+		return (a, b) => -fn(a, b);
+	}
 
 	static sorters: Record<SORT_ORDER, SortFn> = {
 		alphabetical: this.localeSorter,
-		alphabeticalReverse: this.localeSorterReverse,
+		alphabeticalReverse: this.reverse(this.localeSorter),
 		byCreatedTime: this.ctimeSorter,
-		byCreatedTimeReverse: this.ctimeSorterReverse,
+		byCreatedTimeReverse: this.reverse(this.ctimeSorter),
 		byModifiedTime: this.mtimeSorter,
-		byModifiedTimeReverse: this.mtimeSorterReverse,
+		byModifiedTimeReverse: this.reverse(this.mtimeSorter),
 	};
 
 	public static navigateToNextFile(workspace: Workspace, settings: NeighbouringFileNavigatorPluginSettings) {
@@ -39,7 +34,7 @@ export class NeighbouringFileNavigator {
 			?? settings.defaultSortOrder;
 		console.debug("navigateToNextFile with sort mode", sortOrder);
 		const sortFn = this.sorters[sortOrder];
-		this.navigateToNeighbouringFile(workspace, sortFn, true);
+		this.navigateToNeighbouringFile(workspace, sortFn);
 	}
 
 	public static navigateToPrevFile(workspace: Workspace, settings: NeighbouringFileNavigatorPluginSettings) {
@@ -47,40 +42,40 @@ export class NeighbouringFileNavigator {
 			?? settings.defaultSortOrder;
 		console.debug("navigateToPrevFile with sort mode", sortOrder);
 		const sortFn = this.sorters[sortOrder];
-		this.navigateToNeighbouringFile(workspace, sortFn, false);
+		this.navigateToNeighbouringFile(workspace, this.reverse(sortFn));
 	}
 
 	public static navigateToNextAlphabeticalFile(workspace: Workspace) {
 		console.debug("navigateToNextAlphabeticalFile");
-		this.navigateToNeighbouringFile(workspace, this.localeSorter, true);
+		this.navigateToNeighbouringFile(workspace, this.localeSorter);
 	}
 
 	public static navigateToPrevAlphabeticalFile(workspace: Workspace) {
 		console.debug("navigateToPrevAlphabeticalFile");
-		this.navigateToNeighbouringFile(workspace, this.localeSorter, false);
+		this.navigateToNeighbouringFile(workspace, this.reverse(this.localeSorter));
 	}
 
 	public static navigateToNextCreatedFile(workspace: Workspace) {
 		console.debug("navigateToNextCreatedFile");
-		this.navigateToNeighbouringFile(workspace, this.ctimeSorter, true);
+		this.navigateToNeighbouringFile(workspace, this.ctimeSorter);
 	}
 
 	public static navigateToPrevCreatedFile(workspace: Workspace) {
 		console.debug("navigateToPrevCreatedFile");
-		this.navigateToNeighbouringFile(workspace, this.ctimeSorter, false);
+		this.navigateToNeighbouringFile(workspace, this.reverse(this.ctimeSorter));
 	}
 
 	public static navigateToNextModifiedFile(workspace: Workspace) {
 		console.debug("navigateToNextModifiedFile");
-		this.navigateToNeighbouringFile(workspace, this.mtimeSorter, true);
+		this.navigateToNeighbouringFile(workspace, this.mtimeSorter);
 	}
 
 	public static navigateToPrevModifiedFile(workspace: Workspace) {
 		console.debug("navigateToPrevModifiedFile");
-		this.navigateToNeighbouringFile(workspace, this.mtimeSorter, false);
+		this.navigateToNeighbouringFile(workspace, this.reverse(this.mtimeSorter));
 	}
 
-	public static navigateToNeighbouringFile(workspace: Workspace, sortFn: SortFn, next?: boolean) {
+	public static navigateToNeighbouringFile(workspace: Workspace, sortFn: SortFn) {
 		const activeFile = workspace.getActiveFile();
 		if (!activeFile) return;
 
@@ -91,13 +86,7 @@ export class NeighbouringFileNavigator {
 			(item) => item.name === activeFile.name
 		);
 
-		const toFile = next
-			? files[(currentItem + 1) % files.length]
-			: files[
-			currentItem == 0
-				? files.length - 1
-				: (currentItem - 1) % files.length
-		];
+		const toFile = files[(currentItem + 1) % files.length];
 
 		workspace.getLeaf(false).openFile(toFile as TFile);
 	}

--- a/src/NeighbouringFileNavigator.ts
+++ b/src/NeighbouringFileNavigator.ts
@@ -29,17 +29,20 @@ export class NeighbouringFileNavigator {
 		byModifiedTimeReverse: this.reverse(this.mtimeSorter),
 	};
 
-	public static navigateToNextFile(workspace: Workspace, settings: NeighbouringFileNavigatorPluginSettings) {
-		const sortOrder = workspace.getLeavesOfType('file-explorer')?.first()?.getViewState()?.state?.sortOrder as SORT_ORDER
+	private static getFileExplorerSortOrder(workspace: Workspace, settings: NeighbouringFileNavigatorPluginSettings): SORT_ORDER {
+		return workspace.getLeavesOfType('file-explorer')?.first()?.getViewState()?.state?.sortOrder as SORT_ORDER
 			?? settings.defaultSortOrder;
+	}
+
+	public static navigateToNextFile(workspace: Workspace, settings: NeighbouringFileNavigatorPluginSettings) {
+		const sortOrder = this.getFileExplorerSortOrder(workspace, settings);
 		console.debug("navigateToNextFile with sort mode", sortOrder);
 		const sortFn = this.sorters[sortOrder];
 		this.navigateToNeighbouringFile(workspace, sortFn);
 	}
 
 	public static navigateToPrevFile(workspace: Workspace, settings: NeighbouringFileNavigatorPluginSettings) {
-		const sortOrder = workspace.getLeavesOfType('file-explorer')?.first()?.getViewState()?.state?.sortOrder as SORT_ORDER
-			?? settings.defaultSortOrder;
+		const sortOrder = this.getFileExplorerSortOrder(workspace, settings);
 		console.debug("navigateToPrevFile with sort mode", sortOrder);
 		const sortFn = this.sorters[sortOrder];
 		this.navigateToNeighbouringFile(workspace, this.reverse(sortFn));

--- a/src/NeighbouringFileNavigator.ts
+++ b/src/NeighbouringFileNavigator.ts
@@ -36,14 +36,14 @@ export class NeighbouringFileNavigator {
 
 	public static navigateToNextFile(workspace: Workspace, settings: NeighbouringFileNavigatorPluginSettings) {
 		const sortOrder = this.getFileExplorerSortOrder(workspace, settings);
-		console.debug("navigateToNextFile with sort mode", sortOrder);
+		console.debug("navigateToNextFile with sortOrder", sortOrder);
 		const sortFn = this.sorters[sortOrder];
 		this.navigateToNeighbouringFile(workspace, sortFn);
 	}
 
 	public static navigateToPrevFile(workspace: Workspace, settings: NeighbouringFileNavigatorPluginSettings) {
 		const sortOrder = this.getFileExplorerSortOrder(workspace, settings);
-		console.debug("navigateToPrevFile with sort mode", sortOrder);
+		console.debug("navigateToPrevFile with sortOrder", sortOrder);
 		const sortFn = this.sorters[sortOrder];
 		this.navigateToNeighbouringFile(workspace, this.reverse(sortFn));
 	}

--- a/src/NeighbouringFileNavigator.ts
+++ b/src/NeighbouringFileNavigator.ts
@@ -15,17 +15,17 @@ export class NeighbouringFileNavigator {
 	public static mtimeSorter: SortFn = (a: TFile, b: TFile) => { return b.stat.mtime - a.stat.mtime; };
 
 	public static ctimeSorter: SortFn = (a: TFile, b: TFile) => { return b.stat.ctime - a.stat.ctime; };
-	
+
 	public static reverse(fn: SortFn): SortFn {
 		return (a, b) => -fn(a, b);
 	}
 
 	static sorters: Record<SORT_ORDER, SortFn> = {
 		alphabetical: this.localeSorter,
-		alphabeticalReverse: this.reverse(this.localeSorter),
 		byCreatedTime: this.ctimeSorter,
-		byCreatedTimeReverse: this.reverse(this.ctimeSorter),
 		byModifiedTime: this.mtimeSorter,
+		alphabeticalReverse: this.reverse(this.localeSorter),
+		byCreatedTimeReverse: this.reverse(this.ctimeSorter),
 		byModifiedTimeReverse: this.reverse(this.mtimeSorter),
 	};
 
@@ -50,32 +50,32 @@ export class NeighbouringFileNavigator {
 
 	public static navigateToNextAlphabeticalFile(workspace: Workspace) {
 		console.debug("navigateToNextAlphabeticalFile");
-		this.navigateToNeighbouringFile(workspace, this.localeSorter);
+		this.navigateToNeighbouringFile(workspace, this.sorters.alphabetical);
 	}
 
 	public static navigateToPrevAlphabeticalFile(workspace: Workspace) {
 		console.debug("navigateToPrevAlphabeticalFile");
-		this.navigateToNeighbouringFile(workspace, this.reverse(this.localeSorter));
+		this.navigateToNeighbouringFile(workspace, this.sorters.alphabeticalReverse);
 	}
 
 	public static navigateToNextCreatedFile(workspace: Workspace) {
 		console.debug("navigateToNextCreatedFile");
-		this.navigateToNeighbouringFile(workspace, this.ctimeSorter);
+		this.navigateToNeighbouringFile(workspace, this.sorters.byCreatedTime);
 	}
 
 	public static navigateToPrevCreatedFile(workspace: Workspace) {
 		console.debug("navigateToPrevCreatedFile");
-		this.navigateToNeighbouringFile(workspace, this.reverse(this.ctimeSorter));
+		this.navigateToNeighbouringFile(workspace, this.sorters.byCreatedTimeReverse);
 	}
 
 	public static navigateToNextModifiedFile(workspace: Workspace) {
 		console.debug("navigateToNextModifiedFile");
-		this.navigateToNeighbouringFile(workspace, this.mtimeSorter);
+		this.navigateToNeighbouringFile(workspace, this.sorters.byModifiedTime);
 	}
 
 	public static navigateToPrevModifiedFile(workspace: Workspace) {
 		console.debug("navigateToPrevModifiedFile");
-		this.navigateToNeighbouringFile(workspace, this.reverse(this.mtimeSorter));
+		this.navigateToNeighbouringFile(workspace, this.sorters.byModifiedTimeReverse);
 	}
 
 	public static navigateToNeighbouringFile(workspace: Workspace, sortFn: SortFn) {

--- a/src/NeighbouringFileNavigator.ts
+++ b/src/NeighbouringFileNavigator.ts
@@ -11,26 +11,42 @@ export class NeighbouringFileNavigator {
 			undefined,
 			{ numeric: true, sensitivity: 'base' }
 		);
+	
+	public static localeSorterReverse: SortFn = (a: TFile, b: TFile) =>
+		b.basename.localeCompare(
+			a.basename,
+			undefined,
+			{ numeric: true, sensitivity: 'base' }
+		);
 
-	public static mtimeSorter: SortFn = (a: TFile, b: TFile) => { return a.stat.mtime - b.stat.mtime; };
+	public static mtimeSorterReverse: SortFn = (a: TFile, b: TFile) => { return a.stat.mtime - b.stat.mtime; };
+	public static mtimeSorter: SortFn = (a: TFile, b: TFile) => { return b.stat.mtime - a.stat.mtime; };
 
-	public static ctimeSorter: SortFn = (a: TFile, b: TFile) => { return a.stat.ctime - b.stat.ctime; };
+	public static ctimeSorterReverse: SortFn = (a: TFile, b: TFile) => { return a.stat.ctime - b.stat.ctime; };
+	public static ctimeSorter: SortFn = (a: TFile, b: TFile) => { return b.stat.ctime - a.stat.ctime; };
 
 	static sorters: Record<SORT_ORDER, SortFn> = {
 		alphabetical: this.localeSorter,
+		alphabeticalReverse: this.localeSorterReverse,
 		byCreatedTime: this.ctimeSorter,
+		byCreatedTimeReverse: this.ctimeSorterReverse,
 		byModifiedTime: this.mtimeSorter,
+		byModifiedTimeReverse: this.mtimeSorterReverse,
 	};
 
 	public static navigateToNextFile(workspace: Workspace, settings: NeighbouringFileNavigatorPluginSettings) {
-		console.debug("navigateToNextFile with sort mode", settings.defaultSortOrder);
-		const sortFn = this.sorters[settings.defaultSortOrder];
+		const sortOrder = workspace.getLeavesOfType('file-explorer')?.first()?.getViewState()?.state?.sortOrder as SORT_ORDER
+			?? settings.defaultSortOrder;
+		console.debug("navigateToNextFile with sort mode", sortOrder);
+		const sortFn = this.sorters[sortOrder];
 		this.navigateToNeighbouringFile(workspace, sortFn, true);
 	}
 
 	public static navigateToPrevFile(workspace: Workspace, settings: NeighbouringFileNavigatorPluginSettings) {
-		console.debug("navigateToPrevFile with sort mode", settings.defaultSortOrder);
-		const sortFn = this.sorters[settings.defaultSortOrder];
+		const sortOrder = workspace.getLeavesOfType('file-explorer')?.first()?.getViewState()?.state?.sortOrder as SORT_ORDER
+			?? settings.defaultSortOrder;
+		console.debug("navigateToPrevFile with sort mode", sortOrder);
+		const sortFn = this.sorters[sortOrder];
 		this.navigateToNeighbouringFile(workspace, sortFn, false);
 	}
 

--- a/src/NeighbouringFileNavigatorPluginSettingTab.ts
+++ b/src/NeighbouringFileNavigatorPluginSettingTab.ts
@@ -24,9 +24,7 @@ export default class NeighbouringFileNavigatorPluginSettingTab extends PluginSet
 				dropdown.addOption("byModifiedTime", "Modification Timestamp");
 				dropdown.setValue(this.plugin.settings.defaultSortOrder)
 				dropdown.onChange(async (value: SORT_ORDER) =>	{
-					console.log("sort order", this.plugin.settings.defaultSortOrder);
 					this.plugin.settings.defaultSortOrder = value;
-					console.log("setting sort order", value);
 					await this.plugin.saveSettings();
 				});
 			});

--- a/src/NeighbouringFileNavigatorPluginSettingTab.ts
+++ b/src/NeighbouringFileNavigatorPluginSettingTab.ts
@@ -17,7 +17,7 @@ export default class NeighbouringFileNavigatorPluginSettingTab extends PluginSet
 
 		new Setting(containerEl)
 			.setName('Default Sort Order')
-			.setDesc('Sort Order used for the default command')
+			.setDesc('Fallback sort order used for the default command')
 			.addDropdown((dropdown) => {
 				dropdown.addOption("alphabetical", "Alphabetical");
 				dropdown.addOption("byCreatedTime", "Creation Timestamp");

--- a/src/NeighbouringFileNavigatorPluginSettings.ts
+++ b/src/NeighbouringFileNavigatorPluginSettings.ts
@@ -1,4 +1,10 @@
-export type SORT_ORDER = 'alphabetical' | 'byCreatedTime' | 'byModifiedTime';
+export type SORT_ORDER =
+	  'alphabetical'
+	| 'byCreatedTime'
+	| 'byModifiedTime'
+	| 'alphabeticalReverse'
+	| 'byCreatedTimeReverse'
+	| 'byModifiedTimeReverse';
 
 export default interface NeighbouringFileNavigatorPluginSettings {
 	defaultSortOrder: SORT_ORDER;

--- a/test/NeighbouringFileNavigator.test.ts
+++ b/test/NeighbouringFileNavigator.test.ts
@@ -146,12 +146,12 @@ describe('NeighbouringFileNavigator', () => {
 				mtime: 1704025483489, // 2023-12-31T12:24:43.489Z
 				size: 4380,           // 4.38 KB
 			}),
-			createNote("3", {
+			createNote("1", {
 				ctime: 1700989701724, // 2023-11-26T04:01:41.724Z
 				mtime: 1692456789100, // 2023-08-19T11:13:09.100Z
 				size: 102400,         // 100 KB
 			}),
-			createNote("1", {
+			createNote("3", {
 				ctime: 1672502400000, // 2023-01-01T00:00:00.000Z
 				mtime: 1675180800000, // 2023-02-01T00:00:00.000Z
 				size: 5242880,        // 5 MB
@@ -165,7 +165,7 @@ describe('NeighbouringFileNavigator', () => {
 		expectNeighbours(neighbours).toEqual([ "1", "2", "3" ]);
 	});
 
-	it('should sort files based on midified timestamp', () => {
+	it('should sort files based on modified timestamp', () => {
 		// GIVEN
 		const files = setup([
 			createNote("2", {
@@ -173,12 +173,12 @@ describe('NeighbouringFileNavigator', () => {
 				mtime: 1692456789100, // 2023-08-19T11:13:09.100Z
 				size: 5242880,        // 5 MB
 			}),
-			createNote("1", {
+			createNote("3", {
 				ctime: 1689876543210, // 2023-07-20T01:22:23.210Z
 				mtime: 1675180800000, // 2023-02-01T00:00:00.000Z
 				size: 102400,         // 100 KB
 			}),
-			createNote("3", {
+			createNote("1", {
 				ctime: 1672502400000, // 2023-01-01T00:00:00.000Z
 				mtime: 1704025483489, // 2023-12-31T12:24:43.489Z
 				size: 4380,           // 4.38 KB


### PR DESCRIPTION
these changes make the standard next/prev commands follow the file explorer sort order. this way, you can navigate folders by looking at the file explorer and it will always stay consistent. this required modifying the existing time-based sort functions as well as adding reverse sort order functions.

if the file explorer is disabled, the default sort order is used.

NOTE: I have not added commands for reverse sorting.