### PR TITLE
Swap Next/Prev for time-based ordering to match Obsidian

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Default Commands:
 Commands:
 - Navigate to next file (alphabetical)
 - Navigate to prev file (alphabetical)
-- Navigate to next file (creation timestamp)
-- Navigate to prev file (creation timestamp)
-- Navigate to next file (modified timestamp)
-- Navigate to prev file (modified timestamp)
+- Navigate to older file (creation timestamp)
+- Navigate to newer file (creation timestamp)
+- Navigate to older file (modified timestamp)
+- Navigate to newer file (modified timestamp)
 
 Supported Sorting Modes:
 - Alphabetical: Ordered by file names.
@@ -42,15 +42,16 @@ Or use the [obsidian-vimrc-support](https://github.com/esm7/obsidian-vimrc-suppo
 Example `.obsidian.vimrc`.
 
 ```vimrc
-" navigation to neighbouring files
-exmap next_file obcommand neighbouring-files:next
-exmap prev_file obcommand neighbouring-files:prev
+" define navigation commands
+exmap next_file				 obcommand neighbouring-files:next
+exmap prev_file				 obcommand neighbouring-files:prev
 exmap next_file_alphabetical obcommand neighbouring-files:next-alphabetical
 exmap prev_file_alphabetical obcommand neighbouring-files:prev-alphabetical
-exmap next_file_created obcommand neighbouring-files:next-created
-exmap prev_file_created obcommand neighbouring-files:prev-created
-exmap next_file_modified obcommand neighbouring-files:next-modified
-exmap prev_file_modified obcommand neighbouring-files:prev-modified
+exmap older_file_created	 obcommand neighbouring-files:older-created
+exmap newer_file_created	 obcommand neighbouring-files:newer-created
+exmap older_file_modified	 obcommand neighbouring-files:older-modified
+exmap newer_file_modified	 obcommand neighbouring-files:newer-modified
+" add navigation mappings
 nmap gn :next_file<cr>
 nmap gp :prev_file<cr>
 ```

--- a/src/NeighbouringFileNavigator.ts
+++ b/src/NeighbouringFileNavigator.ts
@@ -58,23 +58,23 @@ export class NeighbouringFileNavigator {
 		this.navigateToNeighbouringFile(workspace, this.sorters.alphabeticalReverse);
 	}
 
-	public static navigateToNextCreatedFile(workspace: Workspace) {
-		console.debug("navigateToNextCreatedFile");
+	public static navigateToOlderCreatedFile(workspace: Workspace) {
+		console.debug("navigateToOlderCreatedFile");
 		this.navigateToNeighbouringFile(workspace, this.sorters.byCreatedTime);
 	}
 
-	public static navigateToPrevCreatedFile(workspace: Workspace) {
-		console.debug("navigateToPrevCreatedFile");
+	public static navigateToNewerCreatedFile(workspace: Workspace) {
+		console.debug("navigateToNewerCreatedFile");
 		this.navigateToNeighbouringFile(workspace, this.sorters.byCreatedTimeReverse);
 	}
 
-	public static navigateToNextModifiedFile(workspace: Workspace) {
-		console.debug("navigateToNextModifiedFile");
+	public static navigateToOlderModifiedFile(workspace: Workspace) {
+		console.debug("navigateToOlderModifiedFile");
 		this.navigateToNeighbouringFile(workspace, this.sorters.byModifiedTime);
 	}
 
-	public static navigateToPrevModifiedFile(workspace: Workspace) {
-		console.debug("navigateToPrevModifiedFile");
+	public static navigateToNewerModifiedFile(workspace: Workspace) {
+		console.debug("navigateToNewerModifiedFile");
 		this.navigateToNeighbouringFile(workspace, this.sorters.byModifiedTimeReverse);
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,27 +37,33 @@ export default class NeighbouringFileNavigatorPlugin extends Plugin {
 			callback: () => NeighbouringFileNavigator.navigateToPrevAlphabeticalFile(this.app.workspace),
 		});
 
-		this.addCommand({
-			id: "older-created",
+		const olderCreatedCommand = {
 			name: "Navigate to older file (creation timestamp)",
 			callback: () => NeighbouringFileNavigator.navigateToOlderCreatedFile(this.app.workspace),
-		});
-		this.addCommand({
-			id: "newer-created",
+		};
+		this.addCommand({ ...olderCreatedCommand, id: "older-created" });
+		this.addCommand({ ...olderCreatedCommand, id: "prev-created" });
+
+		const newerCreatedCommand = {
 			name: "Navigate to newer file (creation timestamp)",
 			callback: () => NeighbouringFileNavigator.navigateToNewerCreatedFile(this.app.workspace),
-		});
+		};
+		this.addCommand({ ...newerCreatedCommand, id: "next-created" });
+		this.addCommand({ ...newerCreatedCommand, id: "newer-created" });
 
-		this.addCommand({
-			id: "older-modified",
+		const olderModifiedCommand = {
 			name: "Navigate to older file (modification timestamp)",
 			callback: () => NeighbouringFileNavigator.navigateToOlderModifiedFile(this.app.workspace),
-		});
-		this.addCommand({
-			id: "newer-modified",
+		};
+		this.addCommand({ ...olderModifiedCommand, id: "older-modified" });
+		this.addCommand({ ...olderModifiedCommand, id: "prev-modified" });
+
+		const newerModifiedCommand = {
 			name: "Navigate to newer file (modification timestamp)",
 			callback: () => NeighbouringFileNavigator.navigateToNewerModifiedFile(this.app.workspace),
-		});
+		};
+		this.addCommand({ ...newerModifiedCommand, id: "next-modified" });
+		this.addCommand({ ...newerModifiedCommand, id: "newer-modified" });
 	}
 
 	onunload() { }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,25 +38,25 @@ export default class NeighbouringFileNavigatorPlugin extends Plugin {
 		});
 
 		this.addCommand({
-			id: "next-created",
-			name: "Navigate to next file (creation timestamp)",
-			callback: () => NeighbouringFileNavigator.navigateToNextCreatedFile(this.app.workspace),
+			id: "older-created",
+			name: "Navigate to older file (creation timestamp)",
+			callback: () => NeighbouringFileNavigator.navigateToOlderCreatedFile(this.app.workspace),
 		});
 		this.addCommand({
-			id: "prev-created",
-			name: "Navigate to prev file (creation timestamp)",
-			callback: () => NeighbouringFileNavigator.navigateToPrevCreatedFile(this.app.workspace),
+			id: "newer-created",
+			name: "Navigate to newer file (creation timestamp)",
+			callback: () => NeighbouringFileNavigator.navigateToNewerCreatedFile(this.app.workspace),
 		});
 
 		this.addCommand({
-			id: "next-modified",
-			name: "Navigate to next file (modification timestamp)",
-			callback: () => NeighbouringFileNavigator.navigateToNextModifiedFile(this.app.workspace),
+			id: "older-modified",
+			name: "Navigate to older file (modification timestamp)",
+			callback: () => NeighbouringFileNavigator.navigateToOlderModifiedFile(this.app.workspace),
 		});
 		this.addCommand({
-			id: "prev-modified",
-			name: "Navigate to prev file (modification timestamp)",
-			callback: () => NeighbouringFileNavigator.navigateToPrevModifiedFile(this.app.workspace),
+			id: "newer-modified",
+			name: "Navigate to newer file (modification timestamp)",
+			callback: () => NeighbouringFileNavigator.navigateToNewerModifiedFile(this.app.workspace),
 		});
 	}
 


### PR DESCRIPTION
Fixes #18

Uses "newer/older" instead of "next/prev" for timestamp based navigation commands.
Keep previous command ids to ensure existing vimrc config doesnt break.