### PR TITLE
Add setting to control folder loop behaviour

### DIFF
--- a/src/NeighbouringFileNavigator.ts
+++ b/src/NeighbouringFileNavigator.ts
@@ -94,12 +94,9 @@ export class NeighbouringFileNavigator {
 			(item) => item.name === activeFile.name
 		);
 
-		let nextIndex: number;
-		if (this.settings.disableFolderLooping) {
-			nextIndex = Math.min(currentItem + 1, files.length - 1);
-		} else {
-			nextIndex = (currentItem + 1) % files.length;
-		}
+		const nextIndex = this.settings.enableFolderLoop
+			? (currentItem + 1) % files.length
+			: Math.min(currentItem + 1, files.length - 1);
 
 		const toFile = files[nextIndex];
 		workspace.getLeaf(false).openFile(toFile);

--- a/src/NeighbouringFileNavigatorPluginSettingTab.ts
+++ b/src/NeighbouringFileNavigatorPluginSettingTab.ts
@@ -30,12 +30,12 @@ export default class NeighbouringFileNavigatorPluginSettingTab extends PluginSet
 			});
 
 		new Setting(containerEl)
-			.setName('Folder Cycling')
-			.setDesc('Disable navigation to first note cycling through a folder')
+			.setName('Loop Notes in Folder')
+			.setDesc('Navigate to the first note when navigating past the last note in the same folder.')
 			.addToggle((toggle) => {
-				toggle.setValue(this.plugin.settings.disableFolderLooping);
-				toggle.onChange(async (value) => {
-					this.plugin.settings.disableFolderLooping = value;
+				toggle.setValue(this.plugin.settings.enableFolderLoop);
+				toggle.onChange(async (value: boolean) => {
+					this.plugin.settings.enableFolderLoop = value;
 					await this.plugin.saveSettings();
 				});
 			});

--- a/src/NeighbouringFileNavigatorPluginSettings.ts
+++ b/src/NeighbouringFileNavigatorPluginSettings.ts
@@ -8,5 +8,5 @@ export type SORT_ORDER =
 
 export default interface NeighbouringFileNavigatorPluginSettings {
 	defaultSortOrder: SORT_ORDER;
-	disableFolderLooping: boolean;
+	enableFolderLoop: boolean;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { Plugin } from "obsidian";
 
 const DEFAULT_SETTINGS: Partial<NeighbouringFileNavigatorPluginSettings> = {
 	defaultSortOrder: 'alphabetical',
-	disableFolderLooping: false,
+	enableFolderLoop: false,
 };
 
 export default class NeighbouringFileNavigatorPlugin extends Plugin {

--- a/test/NeighbouringFileNavigator.test.ts
+++ b/test/NeighbouringFileNavigator.test.ts
@@ -40,7 +40,7 @@ const expectNeighbours = (files: Array<TFile> ) => {
 describe("NeighbouringFileNavigator", () => {
 	const settings: NeighbouringFileNavigatorPluginSettings = {
 		defaultSortOrder: "alphabetical",
-		disableFolderLooping: false,
+		enableFolderLoop: true,
 	};
 	const navigator = new NeighbouringFileNavigator(settings);
 	const leaf = {
@@ -226,7 +226,7 @@ describe("NeighbouringFileNavigator", () => {
 		expectNeighbours(neighbours).toEqual(["1", "2", "3"]);
 	});
 
-	it("should cycle folders", () => {
+	it("should loop folder", () => {
 		// GIVEN
 		const files = setupFiles(["1", "2", "3"]);
 		workspace.getActiveFile.mockReturnValue(files[2]);
@@ -240,11 +240,11 @@ describe("NeighbouringFileNavigator", () => {
 		expect(leaf.openFile).not.toHaveBeenCalledWith(files[2]);
 	});
 
-	it("should not cycle folders with setting", () => {
+	it("should not loop folders", () => {
 		// GIVEN
 		const files = setupFiles(["1", "2", "3"]);
 		workspace.getActiveFile.mockReturnValue(files[2]);
-		settings.disableFolderLooping = true;
+		settings.enableFolderLoop = false;
 
 		// WHEN
 		navigator.navigateToNextAlphabeticalFile(workspace);


### PR DESCRIPTION
Fix #20: disable note navigation from looping back to the first note after the last note

