### PR TITLE
Feat: navigate across folders

### DIFF
--- a/.changeset/some-candles-begin.md
+++ b/.changeset/some-candles-begin.md
@@ -1,0 +1,5 @@
+---
+"neighbouring-files": patch
+---
+
+Add option to navigate across folder boundaries

--- a/README.md
+++ b/README.md
@@ -54,8 +54,12 @@ In the settings you can enable support for other file types:
 - Specify additional file extensions to include
 
 ### Loop Notes in Folder
-- When disabled: Navigation stops at the beginning/end of a folder
-- When enabled: Navigation loops back to the start/end when reaching the end/beginning
+- When disabled: Navigation stops at the beginning/end of the current folder.
+- When enabled: Navigation loops back to the first/last note in the same folder.
+
+### Continue Across Folders
+- When disabled: Navigation stays within the current folder.
+- When enabled: Reaching a folder boundary continues navigation into adjacent folders.
 
 ### Configure VIMRC keybindings
 Instead of configuring obsidian hotkeys to trigger the navigation commands,

--- a/src/NeighbouringFileNavigator.ts
+++ b/src/NeighbouringFileNavigator.ts
@@ -1,7 +1,7 @@
 import NeighbouringFileNavigatorPluginSettings, {
 	SORT_ORDER,
 } from "NeighbouringFileNavigatorPluginSettings";
-import { TFile, Workspace } from "obsidian";
+import { TAbstractFile, TFile, TFolder, Workspace } from "obsidian";
 
 export type SortFn = (a: TFile, b: TFile) => number;
 
@@ -51,7 +51,7 @@ export class NeighbouringFileNavigator {
 		const sortOrder = this.getFileExplorerSortOrder(workspace);
 		console.debug("navigateToNextFile with sortOrder", sortOrder);
 		const sortFn = NeighbouringFileNavigator.sorters[sortOrder];
-		this.navigateToNeighbouringFile(workspace, sortFn);
+		this.navigateToNeighbouringFile(workspace, sortFn, true);
 	}
 
 	public navigateToPrevFile(workspace: Workspace) {
@@ -61,6 +61,7 @@ export class NeighbouringFileNavigator {
 		this.navigateToNeighbouringFile(
 			workspace,
 			NeighbouringFileNavigator.reverse(sortFn),
+			false,
 		);
 	}
 
@@ -69,6 +70,7 @@ export class NeighbouringFileNavigator {
 		this.navigateToNeighbouringFile(
 			workspace,
 			NeighbouringFileNavigator.sorters.alphabetical,
+			true,
 		);
 	}
 
@@ -77,6 +79,7 @@ export class NeighbouringFileNavigator {
 		this.navigateToNeighbouringFile(
 			workspace,
 			NeighbouringFileNavigator.sorters.alphabeticalReverse,
+			false,
 		);
 	}
 
@@ -85,6 +88,7 @@ export class NeighbouringFileNavigator {
 		this.navigateToNeighbouringFile(
 			workspace,
 			NeighbouringFileNavigator.sorters.byCreatedTime,
+			true,
 		);
 	}
 
@@ -93,6 +97,7 @@ export class NeighbouringFileNavigator {
 		this.navigateToNeighbouringFile(
 			workspace,
 			NeighbouringFileNavigator.sorters.byCreatedTimeReverse,
+			true,
 		);
 	}
 
@@ -101,6 +106,7 @@ export class NeighbouringFileNavigator {
 		this.navigateToNeighbouringFile(
 			workspace,
 			NeighbouringFileNavigator.sorters.byModifiedTime,
+			true,
 		);
 	}
 
@@ -109,48 +115,130 @@ export class NeighbouringFileNavigator {
 		this.navigateToNeighbouringFile(
 			workspace,
 			NeighbouringFileNavigator.sorters.byModifiedTimeReverse,
+			true,
 		);
 	}
 
-	public navigateToNeighbouringFile(workspace: Workspace, sortFn: SortFn) {
+	public navigateToNeighbouringFile(
+		workspace: Workspace,
+		sortFn: SortFn,
+		forward = true,
+	) {
 		const activeFile = workspace.getActiveFile();
 		if (!activeFile) return;
 
 		const files = this.getNeighbouringFiles(activeFile, sortFn);
-		if (!files) return;
+		if (!files.length) return;
 
 		const currentItem = files.findIndex(
 			(item) => item.name === activeFile.name,
 		);
+
+		if (currentItem === -1) return;
 
 		// loop inside folders
 		const nextIndex = this.settings.enableFolderLoop
 			? (currentItem + 1) % files.length
 			: Math.min(currentItem + 1, files.length - 1);
 
-		const toFile = files[nextIndex];
+		let toFile = files[nextIndex];
+
+		const atFolderBoundary =
+			!this.settings.enableFolderLoop &&
+			nextIndex === currentItem &&
+			currentItem === files.length - 1;
+
+		if (atFolderBoundary && this.settings.enableFolderBoundary) {
+			const boundaryFile = this.findBoundaryFile(
+				activeFile,
+				sortFn,
+				forward,
+			);
+			if (boundaryFile) {
+				toFile = boundaryFile;
+			}
+		}
+
+		if (!toFile) return;
 		workspace.getLeaf(false).openFile(toFile);
 	}
 
-	private filterFiletype(files: TFile) {
+	private filterFiletype(file: TFile) {
 		if (this.settings.includedFileTypes === "allFiles") return true;
 
 		if (this.settings.includedFileTypes === "markdownOnly") {
-			return files.extension === "md";
+			return file.extension === "md";
 		} else if (this.settings.includedFileTypes === "additionalExtensions") {
 			return (
-				files.extension === "md" ||
-				this.settings.additionalExtensions.includes(files.extension)
+				file.extension === "md" ||
+				this.settings.additionalExtensions.includes(file.extension)
 			);
 		}
 	}
 
 	public getNeighbouringFiles(file: TFile, sortFn: SortFn): TFile[] {
+		return file.parent
+			? this.getSortedFilesInFolder(file.parent, sortFn)
+			: [];
+	}
+
+	private getSortedFilesInFolder(folder: TFolder, sortFn: SortFn): TFile[] {
 		return (
-			file.parent?.children
-				.filter((f): f is TFile => f instanceof TFile)
-				.filter((f) => this.filterFiletype(f))
+			folder.children
+				?.filter((child): child is TFile => child instanceof TFile)
+				.filter((file) => this.filterFiletype(file))
 				.sort(sortFn) ?? []
 		);
+	}
+
+	private findBoundaryFile(
+		activeFile: TFile,
+		sortFn: SortFn,
+		forward: boolean,
+	): TFile | undefined {
+		let currentFolder = activeFile.parent;
+		if (!currentFolder) return undefined;
+
+		while (currentFolder && currentFolder.parent) {
+			const parentFolder: TFolder = currentFolder.parent;
+			const siblingFolders =
+				parentFolder.children?.filter(
+					(child: TAbstractFile): child is TFolder =>
+						child instanceof TFolder,
+				) ?? [];
+			const folderIndex = siblingFolders.findIndex(
+				(folder: TFolder) => folder === currentFolder,
+			);
+
+			if (folderIndex !== -1) {
+				const step = forward ? 1 : -1;
+				for (
+					let index = folderIndex + step;
+					index >= 0 && index < siblingFolders.length;
+					index += step
+				) {
+					const folder = siblingFolders[index];
+					const sortedFiles = this.getSortedFilesInFolder(
+						folder,
+						sortFn,
+					);
+					if (sortedFiles.length) {
+						return sortedFiles[0];
+					}
+				}
+			}
+
+			const parentFiles = this.getSortedFilesInFolder(
+				parentFolder,
+				sortFn,
+			);
+			if (parentFiles.length) {
+				return parentFiles[0];
+			}
+
+			currentFolder = parentFolder;
+		}
+
+		return undefined;
 	}
 }

--- a/src/NeighbouringFileNavigatorPluginSettingTab.ts
+++ b/src/NeighbouringFileNavigatorPluginSettingTab.ts
@@ -41,6 +41,17 @@ export default class NeighbouringFileNavigatorPluginSettingTab extends PluginSet
 			});
 
 		new Setting(containerEl)
+			.setName('Continue Across Folders')
+			.setDesc('Move to adjacent folders when navigating beyond the current folder boundary.')
+			.addToggle((toggle) => {
+				toggle.setValue(this.plugin.settings.enableFolderBoundary);
+				toggle.onChange(async (value: boolean) => {
+					this.plugin.settings.enableFolderBoundary = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl)
 			.setName('Included File Types')
 			.setDesc('Set which file types to include in the navigation')
 			.addDropdown((dropdown) => {

--- a/src/NeighbouringFileNavigatorPluginSettings.ts
+++ b/src/NeighbouringFileNavigatorPluginSettings.ts
@@ -3,7 +3,7 @@ export const DEFAULT_SETTINGS: NeighbouringFileNavigatorPluginSettings = {
 	defaultSortOrder: "alphabetical",
 	// navigation options
 	enableFolderLoop: false,
-	enableFolderBoundary: true,
+	enableFolderBoundary: false,
 	// file mask
 	includedFileTypes: "markdownOnly",
 	additionalExtensions: ["canvas", "pdf"],

--- a/src/NeighbouringFileNavigatorPluginSettings.ts
+++ b/src/NeighbouringFileNavigatorPluginSettings.ts
@@ -3,6 +3,7 @@ export const DEFAULT_SETTINGS: NeighbouringFileNavigatorPluginSettings = {
 	defaultSortOrder: "alphabetical",
 	// navigation options
 	enableFolderLoop: false,
+	enableFolderBoundary: true,
 	// file mask
 	includedFileTypes: "markdownOnly",
 	additionalExtensions: ["canvas", "pdf"],
@@ -24,6 +25,7 @@ export type INCLUDED_FILE_TYPES =
 export default interface NeighbouringFileNavigatorPluginSettings {
 	defaultSortOrder: SORT_ORDER;
 	enableFolderLoop: boolean;
+	enableFolderBoundary: boolean;
 	includedFileTypes: INCLUDED_FILE_TYPES;
 	additionalExtensions: string[];
 }

--- a/test/NeighbouringFileNavigator.test.ts
+++ b/test/NeighbouringFileNavigator.test.ts
@@ -34,9 +34,28 @@ const setup = (children: Array<TAbstractFile>) => {
 	return children;
 };
 
+const attachChildren = (parent: TFolder, children: Array<TAbstractFile>) => {
+	parent.children = children;
+	children.forEach((child) => (child.parent = parent));
+	return children;
+};
+
 const setupFiles = (names: Array<string>) => {
 	const children = names.map((c) => createNote(c));
 	return setup(children) as TFile[];
+};
+
+const setupFolder = (names: Array<string>, parent?: TFolder) => {
+	const folder = createDir(names.join("-"));
+	const files = names.map((name) => createNote(name));
+	folder.children = files;
+	files.forEach((file) => (file.parent = folder));
+	if (parent) {
+		folder.parent = parent;
+		parent.children = parent.children ?? [];
+		parent.children.push(folder);
+	}
+	return folder;
 };
 
 const expectNeighbours = (files: Array<TFile>) => {
@@ -238,6 +257,69 @@ describe("NeighbouringFileNavigator", () => {
 		});
 	});
 
+	describe("Settings: File Types", () => {
+		it("should include markdown only", () => {
+			// GIVEN
+			settings.includedFileTypes = "markdownOnly";
+			const files = setup([
+				createNote("1"),
+				createNote("2"),
+				createFile("3", "txt"),
+				createFile("4", "pdf"),
+			]);
+
+			// WHEN
+			const neighbours = navigator.getNeighbouringFiles(
+				files[0] as TFile,
+				NeighbouringFileNavigator.localeSorter,
+			);
+
+			// THEN
+			expectNeighbours(neighbours).toEqual(["1", "2"]);
+		});
+
+		it("should include specified extensions", () => {
+			// GIVEN
+			settings.includedFileTypes = "additionalExtensions";
+			settings.additionalExtensions = ["pdf"];
+			const files = setup([
+				createNote("1"),
+				createNote("2"),
+				createFile("3", "txt"),
+				createFile("4", "pdf"),
+			]);
+
+			// WHEN
+			const neighbours = navigator.getNeighbouringFiles(
+				files[0] as TFile,
+				NeighbouringFileNavigator.localeSorter,
+			);
+
+			// THEN
+			expectNeighbours(neighbours).toEqual(["1", "2", "4"]);
+		});
+
+		it("should include all files", () => {
+			// GIVEN
+			settings.includedFileTypes = "allFiles";
+			const files = setup([
+				createNote("1"),
+				createNote("2"),
+				createFile("3", "txt"),
+				createFile("4", "pdf"),
+			]);
+
+			// WHEN
+			const neighbours = navigator.getNeighbouringFiles(
+				files[0] as TFile,
+				NeighbouringFileNavigator.localeSorter,
+			);
+
+			// THEN
+			expectNeighbours(neighbours).toEqual(["1", "2", "3", "4"]);
+		});
+	});
+
 	describe("Settings: Folder Loop", () => {
 		it("should loop folder", () => {
 			// GIVEN
@@ -270,66 +352,55 @@ describe("NeighbouringFileNavigator", () => {
 		});
 	});
 
-	describe("Settings: File Types", () => {
-		it("should include markdown only", () => {
+	describe("Settings: Folder Boundaries", () => {
+		it("should navigate across folders", () => {
 			// GIVEN
-			settings.includedFileTypes = "markdownOnly";
-			const files = setup([
-				createNote("1"),
-				createNote("2"),
-				createFile("3", "txt"),
-				createFile("4", "pdf"),
-			]);
+			const rootFolder = createDir("root");
+			const folderA = setupFolder(["1", "2", "3"], rootFolder);
+			const folderB = setupFolder(["4", "5", "6"], rootFolder);
+			workspace.getActiveFile.mockReturnValue(
+				folderA.children[folderA.children.length - 1],
+			);
+			settings.enableFolderBoundary = true;
 
 			// WHEN
-			const neighbours = navigator.getNeighbouringFiles(
-				files[0] as TFile,
-				NeighbouringFileNavigator.localeSorter
-			);
+			navigator.navigateToNextAlphabeticalFile(workspace);
 
 			// THEN
-			expectNeighbours(neighbours).toEqual(["1", "2"]);
+			expect(leaf.openFile).toHaveBeenCalledWith(folderB.children[0]);
 		});
 
-		it("should include specified extensions", () => {
+		it("should move to an ancestor file when no siblings remain", () => {
 			// GIVEN
-			settings.includedFileTypes = "additionalExtensions";
-			settings.additionalExtensions = ["pdf"];
-			const files = setup([
-				createNote("1"),
-				createNote("2"),
-				createFile("3", "txt"),
-				createFile("4", "pdf"),
-			]);
+			const root = createDir("root");
+			const folderD = createDir("FolderD");
+			const folderE = createDir("FolderE");
+			const folderC = createDir("FolderC");
+			const folderA = createDir("FolderA");
+			const folderB = createDir("FolderB");
+
+			const fileInE = createNote("Ancestor File");
+			const fileA1 = createNote("File A1");
+			const fileA2 = createNote("File A2");
+			const fileB1 = createNote("File B1");
+			const fileB2 = createNote("File B2");
+
+			attachChildren(folderA, [fileA1, fileA2]);
+			attachChildren(folderB, [fileB1, fileB2]);
+			attachChildren(folderC, [folderA, folderB]);
+			attachChildren(folderE, [fileInE, folderC]);
+			attachChildren(folderD, [folderE]);
+			attachChildren(root, [folderD]);
+
+			workspace.getActiveFile.mockReturnValue(fileA1);
+			settings.enableFolderBoundary = true;
 
 			// WHEN
-			const neighbours = navigator.getNeighbouringFiles(
-				files[0] as TFile,
-				NeighbouringFileNavigator.localeSorter
-			);
+			navigator.navigateToPrevAlphabeticalFile(workspace);
 
 			// THEN
-			expectNeighbours(neighbours).toEqual(["1", "2", "4"]);
-		});
-
-		it("should include all files", () => {
-			// GIVEN
-			settings.includedFileTypes = "allFiles";
-			const files = setup([
-				createNote("1"),
-				createNote("2"),
-				createFile("3", "txt"),
-				createFile("4", "pdf"),
-			]);
-
-			// WHEN
-			const neighbours = navigator.getNeighbouringFiles(
-				files[0] as TFile,
-				NeighbouringFileNavigator.localeSorter
-			);
-
-			// THEN
-			expectNeighbours(neighbours).toEqual(["1", "2", "3", "4"]);
+			expect(leaf.openFile).toHaveBeenCalledWith(fileInE);
+			settings.enableFolderBoundary = false;
 		});
 	});
 });


### PR DESCRIPTION
- [x] Adds basic option to allow navigating across folders.
- [x] Adds test vault to repo for local testing

[folder-navigation.webm](https://github.com/user-attachments/assets/e1c53ca8-71f5-411f-9735-7add0546bc59)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Continue Across Folders" toggle setting. When enabled, navigation continues into adjacent folders after reaching a boundary; when disabled, navigation stays within the current folder.

* **Documentation**
  * Clarified "Loop Notes in Folder" behavior and documented the new cross-folder navigation option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->