### PR TITLE
Github Actions Hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,13 @@ updates:
       schedule:
           interval: "weekly"
       open-pull-requests-limit: 5
+      cooldown:
+        default-days: 7
 
     - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
           interval: "weekly"
       open-pull-requests-limit: 5
+      cooldown:
+        default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
       directory: "/" # Location of package manifests
       schedule:
           interval: "weekly"
+
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,10 @@ updates:
       directory: "/" # Location of package manifests
       schedule:
           interval: "weekly"
+      open-pull-requests-limit: 5
 
     - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
           interval: "weekly"
+      open-pull-requests-limit: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Use Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22.x"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+              with:
+                persist-credentials: false
 
             - name: Use Node.js
               uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
             contents: write
 
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
             - name: Use Node.js
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
               with:
                   node-version: "22.x"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
               with:
                   node-version: "22.x"
                   cache: false
+                  package-manager-cache: false
 
             - name: Build plugin
               run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
               uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
               with:
                   node-version: "22.x"
+                  cache: false
 
             - name: Build plugin
               run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
               uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
               with:
                   node-version: "22.x"
-                  cache: false
                   package-manager-cache: false
 
             - name: Build plugin


### PR DESCRIPTION
## CI/CD Security Assessment with two tools:
- [BretFisher/gasa: GitHub Actions Security Assessment](https://github.com/BretFisher/gasa)
- [zizmorcore/zizmor: Static analysis for GitHub Actions](https://github.com/zizmorcore/zizmor)

---

   1. **Pin actions to commit SHAs** — tags like `v5` are mutable; a force-push could redirect them to malicious code. A SHA is immutable — you always
 get exactly that code.

   2. **Explicit workflow permissions** — without a `permissions:` block, workflows inherit broad defaults (often read-write to everything). Setting
 `contents: read` on the build workflow shrinks blast radius if a step is compromised.

   3. **Disable credential persistence** — `actions/checkout` stores the GITHUB_TOKEN in git config by default. Neither workflow pushes back, so
 storing it only adds leak risk via artifacts or malicious steps.

   4. **Disable caching on release workflow** — `setup-node` caches dependencies by default. On a tag-triggered release, a poisoned cache from a
 previous PR run could inject malicious code into release artifacts.

   5. **Dependabot for github-actions** — without it, pinned action SHAs only get updated manually. Dependabot now keeps them current automatically.

   6. **Cooldown + PR limit** — `open-pull-requests-limit: 5` prevents Dependabot flooding with 20+ PRs. `cooldown: default-days: 7` waits a week
 before updating a newly released dependency, giving time for upstream regressions to surface.