### PR TITLE
fix: alphabetical child folder sort to prevent Android rename skip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,18 @@ build:
 install: install-user-vault
 
 install-user-vault: build # install plugin to user vault
-	-mkdir -p $(VAULT)/.obsidian/plugins/neighbouring-files/
-	-cp -rf $(FILES) $(VAULT)/.obsidian/plugins/neighbouring-files/
+	mkdir -p $(VAULT)/.obsidian/plugins/neighbouring-files/
+	cp -rf $(FILES) $(VAULT)/.obsidian/plugins/neighbouring-files/
 
 install-test-vault: build # install plugin to test vault
-	-mkdir -p ./vault/.obsidian/plugins/neighbouring-files/
-	-cp -rf $(FILES) ./vault/.obsidian/plugins/neighbouring-files/
+	mkdir -p ./vault/.obsidian/plugins/neighbouring-files/
+	cp -rf $(FILES) ./vault/.obsidian/plugins/neighbouring-files/
 
 changeset:
 	npx changeset
 
 release:
+	test -z "$$(git status --porcelain)" || (echo "error: working tree not clean" >&2; exit 1)
 	npx changeset version
 	git add .changeset CHANGELOG.md package.json
 	VERSION=$$(node -p "require('./package.json').version"); npm version --allow-same-version --force "$$VERSION" -m "release: %s"

--- a/src/NeighbouringFileNavigator.ts
+++ b/src/NeighbouringFileNavigator.ts
@@ -285,9 +285,11 @@ export class NeighbouringFileNavigator {
 
 	private getChildFolders(folder: TFolder): TFolder[] {
 		return (
-			folder.children?.filter(
-				(child: TAbstractFile): child is TFolder => child instanceof TFolder
-			) ?? []
+			folder.children
+				?.filter((child: TAbstractFile): child is TFolder => child instanceof TFolder)
+				.sort((a, b) =>
+					a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: "base" })
+				) ?? []
 		);
 	}
 

--- a/test/NeighbouringFileNavigator.test.ts
+++ b/test/NeighbouringFileNavigator.test.ts
@@ -398,6 +398,26 @@ describe("NeighbouringFileNavigator", () => {
 			// THEN
 			expect(leaf.openFile).toHaveBeenCalledWith(fileInE);
 		});
+
+		it("crosses to next folder even when children in mtime order (Android rename)", () => {
+			// GIVEN — children in non-alphabetical order, simulating Android mtime reorder
+			const fileA = createNote("A");
+			const fileB2 = createNote("B2");
+			const fileC = createNote("C");
+			setup([
+				createFolder("FolderA", [fileA]),
+				createFolder("FolderC", [fileC]), // C before B2 — mtime order
+				createFolder("FolderB2", [fileB2]), // renamed folder at end
+			]);
+			workspace.getActiveFile.mockReturnValue(fileA);
+
+			// WHEN
+			navigator.navigateToNextAlphabeticalFile(workspace);
+
+			// THEN — should land on B2 (alphabetically sorted), not skip to C
+			expect(leaf.openFile).toHaveBeenCalledWith(fileB2);
+			expect(leaf.openFile).not.toHaveBeenCalledWith(fileC);
+		});
 	});
 
 	describe("Folder Navigation Commands", () => {


### PR DESCRIPTION
On Android, folder.children reorders by mtime after rename,
breaking sibling folder iteration. getChildFolders() now sorts
alphabetically, matching Obsidian's file explorer behavior.

Closes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder navigation by sorting child folders consistently by name.
  * Folder names now follow natural numeric and case-insensitive ordering, making navigation more predictable.

* **Chores**
  * Added streamlined commands for building, testing, installing, and releasing the plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->