### PR TITLE
chore: skip coderabbit review of dependabot prs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+reviews:
+  auto_review:
+    ignore_usernames:
+      - "dependabot[bot]"


### PR DESCRIPTION
Stop CodeRabbit from auto-reviewing Dependabot PRs to save review rate limit. Dependabot PRs are still mergeable as-is; use `@coderabbitai review` on one if a manual pass is ever wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review settings to exclude dependency update-generated changes from automatic reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->