### PR TITLE
fix: bump js-yaml to patched 3.15.1 and 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1971,9 +1971,9 @@
 			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-			"integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+			"version": "3.15.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+			"integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8386,9 +8386,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -9651,9 +9651,9 @@
 			}
 		},
 		"node_modules/read-yaml-file/node_modules/js-yaml": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-			"integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+			"version": "3.15.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+			"integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
Fixes GHSA-5p4m-2wfm-xmqj (CVE-2026-59870), high severity. JS-YAML quadratic CPU in `!!omap` resolution.

- js-yaml 3.15.0 -> 3.15.1 (via @istanbuljs/load-nyc-config, read-yaml-file)
- js-yaml 4.3.0 -> 4.3.1 (hoisted copy shared by @changesets/cli, eslint-plugin-obsidianmd, @eslint/eslintrc)

Dev-only dependency (eslint config + test coverage chain). Lockfile-only change. Build, lint, and all 33 tests pass.