### PR TITLE
fix: drop dead settings display method

### DIFF
--- a/src/NeighbouringFileNavigatorPluginSettingTab.ts
+++ b/src/NeighbouringFileNavigatorPluginSettingTab.ts
@@ -1,7 +1,6 @@
 import NeighbouringFileNavigatorPlugin from "./main";
-import { App, PluginSettingTab, Setting, requireApiVersion } from "obsidian";
+import { App, PluginSettingTab, requireApiVersion } from "obsidian";
 import type { SettingDefinitionItem } from "obsidian";
-import { SORT_ORDER, INCLUDED_FILE_TYPES } from "./NeighbouringFileNavigatorPluginSettings";
 
 export default class NeighbouringFileNavigatorPluginSettingTab extends PluginSettingTab {
 	plugin: NeighbouringFileNavigatorPlugin;
@@ -110,106 +109,5 @@ export default class NeighbouringFileNavigatorPluginSettingTab extends PluginSet
 				},
 			},
 		];
-	}
-
-	display(): void {
-		let { containerEl } = this;
-
-		containerEl.empty();
-
-		new Setting(containerEl)
-			.setName("Default sort order")
-			.setDesc("Fallback sort order used for the default command")
-			.addDropdown((dropdown) => {
-				dropdown.addOption("alphabetical", "Alphabetical");
-				dropdown.addOption("byCreatedTime", "Creation timestamp");
-				dropdown.addOption("byModifiedTime", "Modification timestamp");
-				dropdown.setValue(this.plugin.settings.defaultSortOrder);
-				dropdown.onChange(async (value: string) => {
-					this.plugin.settings.defaultSortOrder = value as SORT_ORDER;
-					await this.plugin.saveSettings();
-				});
-			});
-
-		new Setting(containerEl)
-			.setName("Loop notes in folder")
-			.setDesc(
-				"Navigate to the first note when navigating past the last note in the same folder."
-			)
-			.addToggle((toggle) => {
-				toggle.setValue(this.plugin.settings.enableFolderLoop);
-				toggle.onChange(async (value: boolean) => {
-					this.plugin.settings.enableFolderLoop = value;
-					await this.plugin.saveSettings();
-				});
-			});
-
-		new Setting(containerEl)
-			.setName("Continue across folders")
-			.setDesc("Move to adjacent folders when navigating beyond the current folder boundary.")
-			.addToggle((toggle) => {
-				toggle.setValue(this.plugin.settings.enableFolderBoundary);
-				toggle.onChange(async (value: boolean) => {
-					this.plugin.settings.enableFolderBoundary = value;
-					await this.plugin.saveSettings();
-				});
-			});
-
-		new Setting(containerEl)
-			.setName("Included file types")
-			.setDesc("Set which file types to include in the navigation")
-			.addDropdown((dropdown) => {
-				dropdown.addOption("markdownOnly", "Markdown only");
-				dropdown.addOption("allFiles", "All files");
-				dropdown.addOption("additionalExtensions", "Additional file extensions below");
-				dropdown.setValue(this.plugin.settings.includedFileTypes);
-				dropdown.onChange(async (value: string) => {
-					this.plugin.settings.includedFileTypes = value as INCLUDED_FILE_TYPES;
-					await this.plugin.saveSettings();
-					// eslint-disable-next-line @typescript-eslint/no-deprecated
-					this.display();
-				});
-			});
-
-		new Setting(containerEl)
-			.setName("Mobile navigation button")
-			.setDesc(
-				"Show a floating button on mobile with configurable swipe gestures and tap actions."
-			)
-			.addToggle((toggle) => {
-				toggle.setValue(this.plugin.settings.showMobileFab);
-				toggle.onChange(async (value: boolean) => {
-					this.plugin.settings.showMobileFab = value;
-					await this.plugin.saveSettings();
-					this.plugin.refreshFab();
-				});
-			});
-
-		new Setting(containerEl)
-			.setName("Fab gestures")
-			.setDesc("Configure swipe gestures, tap actions and haptics for the mobile button.")
-			.addButton((button) => {
-				button.setButtonText("Open fab settings").onClick(() => {
-					this.plugin.openFabConfig();
-				});
-			});
-
-		if (this.plugin.settings.includedFileTypes === "additionalExtensions") {
-			new Setting(containerEl)
-				.setName("Extensions")
-				.setDesc(
-					"List of additional file extensions to include in the navigation (comma separated)"
-				)
-				.addText((text) => {
-					text.setPlaceholder("Canvas, PDF");
-					text.setValue(this.plugin.settings.additionalExtensions.join(", "));
-					text.onChange(async (value: string) => {
-						this.plugin.settings.additionalExtensions = value
-							.split(",")
-							.map((ext) => ext.trim());
-						await this.plugin.saveSettings();
-					});
-				});
-		}
 	}
 }


### PR DESCRIPTION
Removes the deprecated `display()` override from the settings tab.

It is dead code: the class uses `getSettingDefinitions()` (returns a non-empty array), so Obsidian never calls `display()`. It also contains a `// eslint-disable-next-line @typescript-eslint/no-deprecated` that eslint-plugin-obsidianmd 0.4.1 forbids suppressing (no-restricted-disable), which blocks PR #68. Deleting the dead method clears both lint errors with no behavior change.

-102 lines. Build, lint, and all tests pass.