### PR TITLE
fix: position fab bottom-right and hide it behind open side drawers

### DIFF
--- a/src/MobileFab.ts
+++ b/src/MobileFab.ts
@@ -73,6 +73,7 @@ export default class MobileFab {
 		this.plugin = plugin;
 		this.workspace = plugin.app.workspace;
 		this.fabEl = this.buildFab();
+		this.normalizeOffsets();
 		this.applyPosition();
 		this.register();
 	}
@@ -239,6 +240,29 @@ export default class MobileFab {
 		}
 	}
 
+	private safeAreaRight() {
+		const raw = getComputedStyle(window.activeDocument.documentElement)
+			.getPropertyValue("--safe-area-inset-right")
+			.trim();
+		const px = parseFloat(raw);
+		return Number.isFinite(px) ? px : 0;
+	}
+
+	/**
+	 * Clamp persisted offsets to the current valid range so values written
+	 * under older layouts (centered anchor) can not push the button off screen.
+	 */
+	private normalizeOffsets() {
+		const vw = window.innerWidth;
+		const vh = window.innerHeight;
+		this.plugin.settings.fabOffsetX = clampOffset(
+			this.offsetX(),
+			-(vw - 80 - this.safeAreaRight()),
+			20
+		);
+		this.plugin.settings.fabOffsetY = clampOffset(this.offsetY(), -(vh - 140), 100);
+	}
+
 	private offsetX() {
 		return Number(this.plugin.settings.fabOffsetX) || 0;
 	}
@@ -261,8 +285,9 @@ export default class MobileFab {
 	private moveDrag(x: number, y: number) {
 		const vw = this.dragViewportW || window.innerWidth;
 		const vh = this.dragViewportH || window.innerHeight;
-		// right-anchored: negative x moves left, 20px right padding is the flush edge
-		this.plugin.settings.fabOffsetX = clampOffset(x, -(vw - 80), 20);
+		// right-anchored: negative x moves left, 20px right padding is the flush
+		// edge; the minimum keeps the button on screen past the safe area
+		this.plugin.settings.fabOffsetX = clampOffset(x, -(vw - 80 - this.safeAreaRight()), 20);
 		this.plugin.settings.fabOffsetY = clampOffset(y, -(vh - 140), 100);
 		this.applyPosition();
 	}

--- a/src/MobileFab.ts
+++ b/src/MobileFab.ts
@@ -64,6 +64,7 @@ export default class MobileFab {
 	private doubleTapTimer: number | null = null;
 	private singleTapTimer: number | null = null;
 	private pointerHandledTap = false;
+	private drawerObserver: MutationObserver | null = null;
 	private startX = 0;
 	private startY = 0;
 	private startTime = 0;
@@ -81,7 +82,14 @@ export default class MobileFab {
 	};
 
 	private updateVisibility = () => {
-		const show = Boolean(this.workspace.getActiveFile());
+		// hide while a side dock drawer covers the note, so the fab only
+		// shows over the current leaf (state classes live on .workspace)
+		const workspaceEl = this.workspace.containerEl;
+		const dockOpen =
+			Boolean(workspaceEl) &&
+			(workspaceEl.classList.contains("is-left-sidedock-open") ||
+				workspaceEl.classList.contains("is-right-sidedock-open"));
+		const show = Boolean(this.workspace.getActiveFile()) && !dockOpen;
 		if (show === this.visible) return;
 		this.visible = show;
 		this.fabEl.classList.toggle("is-visible", show);
@@ -254,7 +262,8 @@ export default class MobileFab {
 	private moveDrag(x: number, y: number) {
 		const vw = this.dragViewportW || window.innerWidth;
 		const vh = this.dragViewportH || window.innerHeight;
-		this.plugin.settings.fabOffsetX = clampOffset(x, -(vw / 2 - 40), vw / 2 - 40);
+		// right-anchored: negative x moves left, 20px right padding is the flush edge
+		this.plugin.settings.fabOffsetX = clampOffset(x, -(vw - 80), 20);
 		this.plugin.settings.fabOffsetY = clampOffset(y, -(vh - 140), 100);
 		this.applyPosition();
 	}
@@ -294,6 +303,15 @@ export default class MobileFab {
 	private register() {
 		this.leafChangeRef = this.workspace.on("active-leaf-change", this.onLeafChange);
 		window.addEventListener("resize", this.onResize);
+		// the mobile drawer slides in/out without an active-leaf change; watch
+		// the is-open class so the fab hides while it covers the note
+		this.drawerObserver = new MutationObserver(() => this.updateVisibility());
+		this.drawerObserver.observe(window.activeDocument.body, {
+			childList: true,
+			subtree: true,
+			attributes: true,
+			attributeFilter: ["class"],
+		});
 		this.updateVisibility();
 	}
 
@@ -334,6 +352,8 @@ export default class MobileFab {
 		this.tracking = false;
 		this.dragging = false;
 		window.removeEventListener("resize", this.onResize);
+		this.drawerObserver?.disconnect();
+		this.drawerObserver = null;
 		this.workspace.offref(this.leafChangeRef);
 		this.fabEl.remove();
 	}

--- a/src/MobileFab.ts
+++ b/src/MobileFab.ts
@@ -73,7 +73,6 @@ export default class MobileFab {
 		this.plugin = plugin;
 		this.workspace = plugin.app.workspace;
 		this.fabEl = this.buildFab();
-		this.normalizeOffsets();
 		this.applyPosition();
 		this.register();
 	}
@@ -212,12 +211,11 @@ export default class MobileFab {
 			}
 			return;
 		}
-		if (!this.swiped) {
-			this.resetPosition();
-			if (Math.hypot(dx, dy) < TAP_THRESHOLD) {
-				this.pointerHandledTap = true;
-				this.handleTap();
-			}
+		// reset the gesture nudge so the button flips back to its resting spot
+		this.resetPosition();
+		if (!this.swiped && Math.hypot(dx, dy) < TAP_THRESHOLD) {
+			this.pointerHandledTap = true;
+			this.handleTap();
 		}
 	};
 
@@ -239,29 +237,6 @@ export default class MobileFab {
 				this.runCommand(singleTapCommand);
 			}, DOUBLE_TAP_TIMEOUT);
 		}
-	}
-
-	private safeAreaRight() {
-		const raw = getComputedStyle(window.activeDocument.documentElement)
-			.getPropertyValue("--safe-area-inset-right")
-			.trim();
-		const px = parseFloat(raw);
-		return Number.isFinite(px) ? px : 0;
-	}
-
-	/**
-	 * Clamp persisted offsets to the current valid range so values written
-	 * under older layouts (centered anchor) can not push the button off screen.
-	 */
-	private normalizeOffsets() {
-		const vw = window.innerWidth;
-		const vh = window.innerHeight;
-		this.plugin.settings.fabOffsetX = clampOffset(
-			this.offsetX(),
-			-(vw - 80 - this.safeAreaRight()),
-			20
-		);
-		this.plugin.settings.fabOffsetY = clampOffset(this.offsetY(), -(vh - 140), 100);
 	}
 
 	private offsetX() {
@@ -286,9 +261,8 @@ export default class MobileFab {
 	private moveDrag(x: number, y: number) {
 		const vw = this.dragViewportW || window.innerWidth;
 		const vh = this.dragViewportH || window.innerHeight;
-		// right-anchored: negative x moves left, 20px right padding is the flush
-		// edge; the minimum keeps the button on screen past the safe area
-		this.plugin.settings.fabOffsetX = clampOffset(x, -(vw - 80 - this.safeAreaRight()), 20);
+		// right-anchored: negative x moves left, 20px right padding is the flush edge
+		this.plugin.settings.fabOffsetX = clampOffset(x, -(vw - 80), 20);
 		this.plugin.settings.fabOffsetY = clampOffset(y, -(vh - 140), 100);
 		this.applyPosition();
 	}

--- a/src/MobileFab.ts
+++ b/src/MobileFab.ts
@@ -73,6 +73,7 @@ export default class MobileFab {
 		this.plugin = plugin;
 		this.workspace = plugin.app.workspace;
 		this.fabEl = this.buildFab();
+		this.normalizeOffsets();
 		this.applyPosition();
 		this.register();
 	}
@@ -240,6 +241,29 @@ export default class MobileFab {
 		}
 	}
 
+	private safeAreaRight() {
+		const raw = getComputedStyle(window.activeDocument.documentElement)
+			.getPropertyValue("--safe-area-inset-right")
+			.trim();
+		const px = parseFloat(raw);
+		return Number.isFinite(px) ? px : 0;
+	}
+
+	/**
+	 * Clamp persisted offsets to the current valid range so values written
+	 * under older layouts (centered anchor) can not push the button off screen.
+	 */
+	private normalizeOffsets() {
+		const vw = window.innerWidth;
+		const vh = window.innerHeight;
+		this.plugin.settings.fabOffsetX = clampOffset(
+			this.offsetX(),
+			-(vw - 80 - this.safeAreaRight()),
+			20
+		);
+		this.plugin.settings.fabOffsetY = clampOffset(this.offsetY(), -(vh - 140), 100);
+	}
+
 	private offsetX() {
 		return Number(this.plugin.settings.fabOffsetX) || 0;
 	}
@@ -262,8 +286,9 @@ export default class MobileFab {
 	private moveDrag(x: number, y: number) {
 		const vw = this.dragViewportW || window.innerWidth;
 		const vh = this.dragViewportH || window.innerHeight;
-		// right-anchored: negative x moves left, 20px right padding is the flush edge
-		this.plugin.settings.fabOffsetX = clampOffset(x, -(vw - 80), 20);
+		// right-anchored: negative x moves left, 20px right padding is the flush
+		// edge; the minimum keeps the button on screen past the safe area
+		this.plugin.settings.fabOffsetX = clampOffset(x, -(vw - 80 - this.safeAreaRight()), 20);
 		this.plugin.settings.fabOffsetY = clampOffset(y, -(vh - 140), 100);
 		this.applyPosition();
 	}

--- a/src/MobileFab.ts
+++ b/src/MobileFab.ts
@@ -60,6 +60,9 @@ export default class MobileFab {
 	private dragBaseY = 0;
 	private dragViewportW = 0;
 	private dragViewportH = 0;
+	private lastViewportW = 0;
+	private lastViewportH = 0;
+	private lastSafeAreaRight = 0;
 	private longPressTimer: number | null = null;
 	private doubleTapTimer: number | null = null;
 	private singleTapTimer: number | null = null;
@@ -75,6 +78,9 @@ export default class MobileFab {
 		this.fabEl = this.buildFab();
 		this.normalizeOffsets();
 		this.applyPosition();
+		this.lastViewportW = window.innerWidth;
+		this.lastViewportH = window.innerHeight;
+		this.lastSafeAreaRight = this.safeAreaRight();
 		this.register();
 	}
 
@@ -97,10 +103,27 @@ export default class MobileFab {
 	};
 
 	private onResize = () => {
+		const vw = window.innerWidth;
+		const vh = window.innerHeight;
+		const safeAreaRight = this.safeAreaRight();
+		// no active drag: rotation or a safe-area change can shrink the usable
+		// viewport, so reclamp persisted offsets that are now out of range
+		if (!this.tracking || !this.dragging) {
+			if (
+				vw !== this.lastViewportW ||
+				vh !== this.lastViewportH ||
+				safeAreaRight !== this.lastSafeAreaRight
+			) {
+				this.normalizeOffsets();
+				this.applyPosition();
+				this.lastViewportW = vw;
+				this.lastViewportH = vh;
+				this.lastSafeAreaRight = safeAreaRight;
+			}
+			return;
+		}
 		// keyboard opening shrinks the viewport and re-anchors the fixed
 		// bottom position; keep the fab under the finger mid-drag
-		if (!this.tracking || !this.dragging) return;
-		const vh = window.innerHeight;
 		const dy = this.dragViewportH - vh;
 		if (dy !== 0) {
 			this.plugin.settings.fabOffsetY = clampOffset(

--- a/src/MobileFab.ts
+++ b/src/MobileFab.ts
@@ -350,15 +350,16 @@ export default class MobileFab {
 	private register() {
 		this.leafChangeRef = this.workspace.on("active-leaf-change", this.onLeafChange);
 		window.addEventListener("resize", this.onResize);
-		// the mobile drawer slides in/out without an active-leaf change; watch
-		// the is-open class so the fab hides while it covers the note
+		// the mobile drawer slides in/out without an active-leaf change; the
+		// is-open class lives on the workspace container, so watch just that
+		// element instead of the whole document to avoid constant churn
 		this.drawerObserver = new MutationObserver(() => this.updateVisibility());
-		this.drawerObserver.observe(window.activeDocument.body, {
-			childList: true,
-			subtree: true,
-			attributes: true,
-			attributeFilter: ["class"],
-		});
+		if (this.workspace.containerEl) {
+			this.drawerObserver.observe(this.workspace.containerEl, {
+				attributes: true,
+				attributeFilter: ["class"],
+			});
+		}
 		this.updateVisibility();
 	}
 

--- a/styles.css
+++ b/styles.css
@@ -2,10 +2,9 @@
 
 .neighbouring-files-fab {
 	position: fixed;
-	left: 50%;
+	right: calc(var(--safe-area-inset-right, 0px) + 20px);
 	bottom: calc(var(--safe-area-inset-bottom, 0px) + 64px);
-	transform: translateX(calc(-50% + var(--fab-drag-x, 0px)))
-		translateY(var(--fab-drag-y, 0px));
+	transform: translateX(var(--fab-drag-x, 0px)) translateY(var(--fab-drag-y, 0px));
 	width: 60px;
 	height: 60px;
 	border-radius: 50%;
@@ -16,7 +15,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	z-index: var(--layer-modal);
+	z-index: var(--layer-backdrop, 5);
 	opacity: 0;
 	pointer-events: none;
 	transition: opacity 0.15s ease, transform 0.15s ease;

--- a/test/MobileFab.test.ts
+++ b/test/MobileFab.test.ts
@@ -208,14 +208,17 @@ describe("MobileFab", () => {
 	});
 
 	describe("visibility", () => {
-		it("hides the fab while a side dock drawer is open", () => {
+		it("hides the fab while a side dock drawer is open", async () => {
 			const { workspace } = mount();
 			const container = workspace.containerEl as HTMLElement;
 			const fab = getFab();
+			jest.useRealTimers();
 			expect(fab.classList.contains("is-visible")).toBe(true);
 			container.classList.add("is-left-sidedock-open");
+			await new Promise((r) => setTimeout(r, 10));
 			expect(fab.classList.contains("is-visible")).toBe(false);
 			container.classList.remove("is-left-sidedock-open");
+			await new Promise((r) => setTimeout(r, 10));
 			expect(fab.classList.contains("is-visible")).toBe(true);
 		});
 	});

--- a/test/MobileFab.test.ts
+++ b/test/MobileFab.test.ts
@@ -23,6 +23,7 @@ const makeWorkspace = (activeFile: unknown = { path: "a.md" }) => {
 		on: jest.fn(() => () => {}),
 		offref: jest.fn(),
 		getActiveFile: jest.fn(() => activeFile),
+		containerEl: document.createElement("div"),
 	};
 	return workspace as unknown as Record<string, unknown> & {
 		on: jest.Mock;

--- a/test/MobileFab.test.ts
+++ b/test/MobileFab.test.ts
@@ -179,6 +179,27 @@ describe("MobileFab", () => {
 		});
 	});
 
+	describe("resize", () => {
+		afterEach(() => {
+			// restore the default viewport between tests
+			Object.defineProperty(window, "innerWidth", {
+				value: 1024,
+				configurable: true,
+			});
+		});
+
+		it("reclamps offsets that fall out of range after a viewport change", () => {
+			// -200 is in range for the default 1024px viewport but not after the
+			// shrink below, so only the resize handler can pull it back in bounds
+			const { plugin } = mount({ fabOffsetX: "-200" });
+			// shrink the viewport, then fire the resize event the handler listens for
+			Object.defineProperty(window, "innerWidth", { value: 200, configurable: true });
+			window.dispatchEvent(new Event("resize"));
+			// min bound at 200px wide minus the 80px fab gutter = -120
+			expect(plugin.settings.fabOffsetX).toBeGreaterThanOrEqual(-120);
+		});
+	});
+
 	describe("keyboard / assistive activation", () => {
 		it("runs the single-tap command from a plain click", () => {
 			mount();

--- a/test/MobileFab.test.ts
+++ b/test/MobileFab.test.ts
@@ -23,7 +23,8 @@ const makeWorkspace = (activeFile: unknown = { path: "a.md" }) => {
 		on: jest.fn(() => () => {}),
 		offref: jest.fn(),
 		getActiveFile: jest.fn(() => activeFile),
-		containerEl: document.createElement("div"),
+		// appended to the body so the fab's mutation observer sees class changes
+		containerEl: document.body.appendChild(document.createElement("div")),
 	};
 	return workspace as unknown as Record<string, unknown> & {
 		on: jest.Mock;
@@ -203,6 +204,19 @@ describe("MobileFab", () => {
 			fire("pointerup", 0, 0);
 			jest.advanceTimersByTime(DOUBLE_TAP_TIMEOUT + 10);
 			expect(Notice.instances.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe("visibility", () => {
+		it("hides the fab while a side dock drawer is open", () => {
+			const { workspace } = mount();
+			const container = workspace.containerEl as HTMLElement;
+			const fab = getFab();
+			expect(fab.classList.contains("is-visible")).toBe(true);
+			container.classList.add("is-left-sidedock-open");
+			expect(fab.classList.contains("is-visible")).toBe(false);
+			container.classList.remove("is-left-sidedock-open");
+			expect(fab.classList.contains("is-visible")).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
Fixes two mobile UI issues found while testing the FAB:

1. **Default position** - the FAB was centered on the left edge of the screen. It now sits bottom-right with a small padding, cleared from Obsidian's mobile tab bar. Drag clamping was re-anchored to the new right-aligned layout.

2. **Sidebar overlap** - the FAB (z-index layer-modal) painted on top of the mobile side drawer when it slides in. The FAB now sits at layer-backdrop, so any overlay (side drawer, modal) covers it. A mutation observer also hides the FAB while the side dock is open.

3. **Gesture feedback** - after a swipe the button now flips back to its resting position instead of staying nudged in the swipe direction.

**Demo Video**

https://github.com/user-attachments/assets/573f5428-123b-43c6-98b5-d3f3d9f21493



Verified: build, lint, 34 tests, prettier all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The mobile floating navigation button now hides reliably when side docks open, including during drawer transitions.
  - Improved dragging behavior near the right screen edge and safe-area insets.
  - Saved button positions are automatically corrected when they fall outside the usable area.
  - The button’s position now resets consistently after dragging or swiping.
  - Improved layering and positioning across supported mobile layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->