### PR TITLE
fix: create mobile fab on body element

### DIFF
--- a/.changeset/tidy-buttons-brake.md
+++ b/.changeset/tidy-buttons-brake.md
@@ -1,0 +1,5 @@
+---
+"neighbouring-files": patch
+---
+
+Fix plugin failing to load on Android: the mobile FAB was created on the popout-window document, which is unavailable on mobile. Create it on the document body instead.

--- a/src/MobileFab.ts
+++ b/src/MobileFab.ts
@@ -263,8 +263,16 @@ export default class MobileFab {
 		}
 	}
 
+	/**
+	 * Active document, with fallback for mobile where the popout-window
+	 * API (activeDocument) is not initialized.
+	 */
+	private static activeDoc() {
+		return window.activeDocument ?? window.document;
+	}
+
 	private safeAreaRight() {
-		const raw = getComputedStyle(window.activeDocument.documentElement)
+		const raw = getComputedStyle(MobileFab.activeDoc().documentElement)
 			.getPropertyValue("--safe-area-inset-right")
 			.trim();
 		const px = parseFloat(raw);
@@ -327,15 +335,14 @@ export default class MobileFab {
 	};
 
 	private buildFab(): HTMLElement {
-		const doc = window.activeDocument;
-		const fab = doc.createEl("button", {
+		const doc = MobileFab.activeDoc();
+		const fab = doc.body.createEl("button", {
 			cls: "neighbouring-files-fab",
 			attr: { "aria-label": "Navigate to neighbouring files", type: "button" },
 		});
 
-		const icon = doc.createSpan();
+		const icon = fab.createSpan();
 		setIcon(icon, "circle-dot");
-		fab.append(icon);
 
 		fab.addEventListener("pointerdown", this.onPointerDown);
 		fab.addEventListener("pointermove", this.onPointerMove);
@@ -343,7 +350,6 @@ export default class MobileFab {
 		fab.addEventListener("pointercancel", this.onPointerUp);
 		fab.addEventListener("click", this.onClick);
 
-		doc.body.appendChild(fab);
 		return fab;
 	}
 

--- a/test/MobileFab.test.ts
+++ b/test/MobileFab.test.ts
@@ -255,4 +255,27 @@ describe("MobileFab", () => {
 			expect(fab).toBeDefined();
 		});
 	});
+
+	describe("activeDoc fallback", () => {
+		// Regression for the mobile path where the popout-window API is
+		// unavailable: activeDoc() must fall back to window.document.
+		const unsetActiveDocument = () => {
+			(window as unknown as { activeDocument: Document | undefined }).activeDocument =
+				undefined;
+		};
+
+		it("creates the fab on the document body when activeDocument is unavailable", () => {
+			unsetActiveDocument();
+			mount();
+			const fabEl = getFab();
+			expect(document.body.contains(fabEl)).toBe(true);
+		});
+
+		it("removes the fab on unload when using the fallback document", () => {
+			unsetActiveDocument();
+			mount();
+			fab.onunload();
+			expect(document.body.querySelector(".neighbouring-files-fab")).toBeNull();
+		});
+	});
 });

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -17,39 +17,68 @@ if (typeof HTMLElement !== "undefined") {
 	HTMLElement.prototype.setPointerCapture = function () {};
 }
 
-// Obsidian also patches Document with a createEl/createSpan helper. jsdom only
-// has createElement, so mirror the minimal shape MobileFab uses.
+// Obsidian also patches Document and HTMLElement with createEl/createSpan
+// helpers (document.body.createEl, this.contentEl.createSpan, etc.). jsdom
+// only has createElement, so mirror the minimal shape MobileFab uses. Both
+// prototypes share one implementation since the helpers accept any element
+// or document as `this`.
+
+/**
+ * Resolve the owning document for the `this` receiver. A Document is itself
+ * the document; an element exposes it via ownerDocument.
+ */
+const owningDoc = (receiver: unknown): Document => {
+	if (typeof Document !== "undefined" && receiver instanceof Document) return receiver;
+	return (receiver as { ownerDocument?: Document }).ownerDocument ?? (receiver as Document);
+};
+
+/** Minimal shape of the Obsidian createEl options MobileFab uses. */
+type CreateElOptions = {
+	cls?: string;
+	attr?: Record<string, string>;
+};
+
+// Names avoid the ambient `createEl`/`createSpan` globals declared by the
+// Obsidian typings (obsidian.d.ts `declare global`), which would collide.
+const makeEl = function (this: unknown, tag: string, options?: CreateElOptions): HTMLElement {
+	const el = owningDoc(this).createElement(tag);
+	if (options?.cls) el.className = options.cls;
+	const attr = options?.attr;
+	if (attr) {
+		for (const key in attr) {
+			el.setAttribute(key, attr[key]);
+		}
+	}
+	// Obsidian's createEl appends the new element to the receiver by default;
+	// a Document appends to its body.
+	const node = this as Node | null;
+	if (node) {
+		if (node.nodeType === 9) {
+			(node as Document).body.appendChild(el);
+		} else {
+			node.appendChild(el);
+		}
+	}
+	return el;
+};
+const makeSpan = function (this: unknown, options?: CreateElOptions): HTMLSpanElement {
+	return makeEl.call(this, "span", options);
+};
+
+type CreateHelperTarget = {
+	createEl: (this: unknown, tag: string, options?: CreateElOptions) => HTMLElement;
+	createSpan: (this: unknown, options?: CreateElOptions) => HTMLSpanElement;
+};
+
 if (typeof Document !== "undefined") {
-	(
-		Document.prototype as unknown as {
-			createEl: (tag: string, options?: Record<string, unknown>) => HTMLElement;
-			createSpan: (options?: Record<string, unknown>) => HTMLSpanElement;
-		}
-	).createEl = function (
-		this: Document,
-		tag: string,
-		options?: Record<string, unknown>
-	): HTMLElement {
-		const el = this.createElement(tag);
-		if (options?.cls) el.className = String(options.cls);
-		const attr = options?.attr as Record<string, string> | undefined;
-		if (attr) {
-			for (const key in attr) {
-				el.setAttribute(key, attr[key]);
-			}
-		}
-		return el;
-	};
-	(
-		Document.prototype as unknown as {
-			createEl: (tag: string, options?: Record<string, unknown>) => HTMLElement;
-			createSpan: (options?: Record<string, unknown>) => HTMLSpanElement;
-		}
-	).createSpan = function (this: Document, options?: Record<string, unknown>): HTMLSpanElement {
-		return (
-			this as unknown as {
-				createEl: (tag: string, options?: Record<string, unknown>) => HTMLElement;
-			}
-		).createEl("span", options) as HTMLSpanElement;
-	};
+	Object.assign(Document.prototype as unknown as CreateHelperTarget, {
+		createEl: makeEl,
+		createSpan: makeSpan,
+	});
+}
+if (typeof HTMLElement !== "undefined") {
+	Object.assign(HTMLElement.prototype as unknown as CreateHelperTarget, {
+		createEl: makeEl,
+		createSpan: makeSpan,
+	});
 }


### PR DESCRIPTION
Fixes #87 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile floating action button creation when the popout-window API is unavailable.
  * Ensured safe-area positioning works correctly across mobile document contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->